### PR TITLE
feature: Remove the ability to use Symbol as a literal

### DIFF
--- a/paseri-lib/src/schemas/literal.test.ts
+++ b/paseri-lib/src/schemas/literal.test.ts
@@ -113,38 +113,6 @@ test('Boolean', async (t) => {
     });
 });
 
-test('Symbol', async (t) => {
-    const symbolLiteral = Symbol.for('test');
-    const schema = p.literal(symbolLiteral);
-
-    await t.step('Valid', () => {
-        const data = Symbol.for('test');
-
-        const result = schema.safeParse(data);
-
-        if (result.ok) {
-            expect(result.value).toBe(symbolLiteral);
-        } else {
-            expect(result.ok).toBeTruthy();
-        }
-    });
-
-    await t.step('Invalid', () => {
-        const data = Symbol.for('other');
-
-        const result = schema.safeParse(data);
-        if (!result.ok) {
-            expect(result.messages()).toEqual([{ path: [], message: "Invalid value. Expected Symbol('test')." }]);
-        } else {
-            expect(result.ok).toBeFalsy();
-        }
-    });
-
-    await t.step('Value', () => {
-        expectTypeOf(schema.value).toEqualTypeOf<typeof symbolLiteral>;
-    });
-});
-
 test('Optional', () => {
     const schema = p.literal('apple').optional();
 

--- a/paseri-lib/src/schemas/literal.ts
+++ b/paseri-lib/src/schemas/literal.ts
@@ -4,7 +4,7 @@ import type { InternalParseResult } from '../result.ts';
 import { primitiveToString } from '../utils.ts';
 import { Schema } from './schema.ts';
 
-type LiteralType = string | number | bigint | boolean | symbol;
+type LiteralType = string | number | bigint | boolean;
 
 class LiteralSchema<OutputType extends LiteralType> extends Schema<OutputType> {
     private readonly _value: OutputType;


### PR DESCRIPTION
They are not technically literals, and this also matches the behaviour of Zod 4.