### PR TITLE
refactor: Harden CI workflows and add PR metric reports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -2,21 +2,29 @@ name: Bundle size
 
 on:
   workflow_call:
-    secrets:
-      GIST_SECRET:
-        required: true
+    outputs:
+      bundle_size:
+        description: "Minzipped bundle size."
+        value: ${{ jobs.bundle-size.outputs.bundle_size }}
+
+permissions: {}
 
 jobs:
   bundle-size:
     name: Calculate bundle size
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      bundle_size: ${{ steps.bundle.outputs.BUNDLE_SIZE }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: "^2.7.14"
 
@@ -25,14 +33,100 @@ jobs:
         working-directory: paseri-lib
         run: |
           echo "BUNDLE_SIZE=$(deno task calculate_bundle_size)" >> $GITHUB_OUTPUT
-          echo "GIST_PATH=$(echo "${{ github.repository }}/${{ github.ref_name }}" | sed 's/\//_/g')-bundlesize.svg" >> $GITHUB_OUTPUT
 
-      - name: Create bundle size badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+      - name: Write main metric
+        if: github.ref == 'refs/heads/main'
+        run: printf '%s' "${{ steps.bundle.outputs.BUNDLE_SIZE }}" > main-bundlesize.txt
+
+      - name: Save main bundle size metric
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: 80548a1b87f9f00fe1ae426ca6a2a517
-          filename: ${{ steps.bundle.outputs.GIST_PATH }}
-          label: minzip
-          message: ${{ steps.bundle.outputs.BUNDLE_SIZE }}
-          color: blue
+          path: main-bundlesize.txt
+          key: main-metrics-bundlesize-${{ github.sha }}
+
+      - name: Restore main bundle size metric
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: main-bundlesize.txt
+          key: main-metrics-bundlesize-
+          restore-keys: |
+            main-metrics-bundlesize-
+
+      - name: Compute bundle size delta
+        if: github.event_name == 'pull_request'
+        id: delta
+        run: |
+          pr_size="${{ steps.bundle.outputs.BUNDLE_SIZE }}"
+          # Strict whitelist on PR value (digits, dot, single trailing IEC suffix).
+          pr_size=$(printf '%s' "$pr_size" | tr -cd '0-9.KMG' | head -c 16)
+          if [ -f main-bundlesize.txt ]; then
+            main_size=$(tr -cd '0-9.KMG' < main-bundlesize.txt | head -c 16)
+            if [ "$pr_size" = "$main_size" ]; then
+              delta="no change"
+            else
+              delta="${main_size} → ${pr_size}"
+            fi
+          else
+            main_size="no cached baseline"
+            delta="n/a"
+          fi
+          {
+            echo "## Bundle size (minzip)"
+            echo ""
+            echo "| Branch | Value |"
+            echo "|--------|-------|"
+            echo "| This PR | ${pr_size} |"
+            echo "| main    | ${main_size} |"
+            echo "| Δ       | ${delta} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "pr_size=$pr_size"
+            echo "main_size=$main_size"
+            echo "delta=$delta"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post bundle size comment
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_SIZE: ${{ steps.delta.outputs.pr_size }}
+          MAIN_SIZE: ${{ steps.delta.outputs.main_size }}
+          DELTA: ${{ steps.delta.outputs.delta }}
+        with:
+          script: |
+            const marker = '<!-- paseri-bundle-size -->';
+            const body = [
+              marker,
+              '## Bundle size (minzip)',
+              '',
+              '| Branch | Value |',
+              '|--------|-------|',
+              `| This PR | ${process.env.PR_SIZE} |`,
+              `| main    | ${process.env.MAIN_SIZE} |`,
+              `| Δ       | ${process.env.DELTA} |`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,17 +2,21 @@ name: Commit lint
 
 on: workflow_call
 
+permissions: {}
+
 jobs:
   unit:
     name: Commit lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: "^2.7.14"
 
@@ -22,7 +26,7 @@ jobs:
         run: |
           echo "DENO_DIR=$(deno info | grep DENO_DIR | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d ':' -f 2 | xargs)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         name: Setup Deno cache
         with:
           path: ${{ steps.deno-cache.outputs.DENO_DIR }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,21 @@ name: Lint
 
 on: workflow_call
 
+permissions: {}
+
 jobs:
   unit:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: "^2.7.14"
 
@@ -22,7 +26,7 @@ jobs:
         run: |
           echo "DENO_DIR=$(deno info | grep DENO_DIR | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d ':' -f 2 | xargs)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         name: Setup Deno cache
         with:
           path: ${{ steps.deno-cache.outputs.DENO_DIR }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,21 +6,29 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   lint:
+    permissions:
+      contents: read
     uses: ./.github/workflows/lint.yml
 
   commitlint:
+    permissions:
+      contents: read
     uses: ./.github/workflows/commitlint.yml
 
   test:
     needs: [lint, commitlint]
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/test.yml
-    secrets:
-      GIST_SECRET: ${{ secrets.GIST_SECRET }}
 
   bundle-size:
     needs: [lint, commitlint]
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/bundle-size.yml
-    secrets:
-      GIST_SECRET: ${{ secrets.GIST_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,63 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/test.yml
-    secrets:
-      GIST_SECRET: ${{ secrets.GIST_SECRET }}
+    with:
+      use_cache: false
 
   bundle-size:
+    permissions:
+      contents: read
     uses: ./.github/workflows/bundle-size.yml
-    secrets:
-      GIST_SECRET: ${{ secrets.GIST_SECRET }}
+
+  badges:
+    needs: [test, bundle-size]
+    runs-on: ubuntu-latest
+    environment: badges
+    permissions: {}
+    steps:
+      - name: Update coverage badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 80548a1b87f9f00fe1ae426ca6a2a517
+          filename: vbudovski_paseri_main-coverage.svg
+          label: coverage
+          message: ${{ needs.test.outputs.coverage }}%
+          valColorRange: ${{ needs.test.outputs.coverage }}
+          minColorRange: 50
+          maxColorRange: 90
+
+      - name: Update bundle size badge
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 80548a1b87f9f00fe1ae426ca6a2a517
+          filename: vbudovski_paseri_main-bundlesize.svg
+          label: minzip
+          message: ${{ needs.bundle-size.outputs.bundle_size }}
+          color: blue
 
   publish:
     needs: test
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: "^2.7.14"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,31 +2,46 @@ name: Test
 
 on:
   workflow_call:
-    secrets:
-      GIST_SECRET:
-        required: true
+    inputs:
+      use_cache:
+        description: "Restore and save the Deno cache."
+        type: boolean
+        default: true
+    outputs:
+      coverage:
+        description: "Code coverage percentage from the test run."
+        value: ${{ jobs.unit.outputs.coverage }}
+
+permissions: {}
 
 jobs:
   unit:
     name: Run unit tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      coverage: ${{ steps.tests.outputs.CODE_COVERAGE }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
           deno-version: "^2.7.14"
 
-      - name: Get pnpm store directory
+      - name: Get DENO_DIR
+        if: ${{ inputs.use_cache }}
         id: deno-cache
         shell: bash
         run: |
           echo "DENO_DIR=$(deno info | grep DENO_DIR | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d ':' -f 2 | xargs)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: ${{ inputs.use_cache }}
         name: Setup Deno cache
         with:
           path: ${{ steps.deno-cache.outputs.DENO_DIR }}
@@ -39,16 +54,100 @@ jobs:
         run: |
           deno test -P --doc --coverage
           echo "CODE_COVERAGE=$(deno coverage | grep "All files" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d '|' -f 3 | xargs)" >> $GITHUB_OUTPUT
-          echo "GIST_PATH=$(echo "${{ github.repository }}/${{ github.ref_name }}" | sed 's/\//_/g')-coverage.svg" >> $GITHUB_OUTPUT
 
-      - name: Create coverage badge
-        uses: schneegans/dynamic-badges-action@v1.8.0
+      - name: Write main metric
+        if: github.ref == 'refs/heads/main'
+        run: printf '%s' "${{ steps.tests.outputs.CODE_COVERAGE }}" > main-coverage.txt
+
+      - name: Save main coverage metric
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: 80548a1b87f9f00fe1ae426ca6a2a517
-          filename: ${{ steps.tests.outputs.GIST_PATH }}
-          label: coverage
-          message: ${{ steps.tests.outputs.CODE_COVERAGE }}%
-          valColorRange: ${{ steps.tests.outputs.CODE_COVERAGE }}
-          minColorRange: 50
-          maxColorRange: 90
+          path: main-coverage.txt
+          key: main-metrics-coverage-${{ github.sha }}
+
+      - name: Restore main coverage metric
+        if: github.event_name == 'pull_request'
+        id: restore
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: main-coverage.txt
+          key: main-metrics-coverage-
+          restore-keys: |
+            main-metrics-coverage-
+
+      - name: Compute coverage delta
+        if: github.event_name == 'pull_request'
+        id: delta
+        run: |
+          pr_cov="${{ steps.tests.outputs.CODE_COVERAGE }}"
+          # Strict numeric whitelist on PR value.
+          pr_cov=$(printf '%s' "$pr_cov" | tr -cd '0-9.' | head -c 8)
+          if [ -f main-coverage.txt ]; then
+            main_cov=$(tr -cd '0-9.' < main-coverage.txt | head -c 8)
+            delta=$(awk -v a="$pr_cov" -v b="$main_cov" 'BEGIN { printf "%+.2f", a - b }')
+            main_display="${main_cov}%"
+          else
+            main_cov=""
+            delta="n/a"
+            main_display="no cached baseline"
+          fi
+          {
+            echo "## Coverage"
+            echo ""
+            echo "| Branch | Value |"
+            echo "|--------|-------|"
+            echo "| This PR | ${pr_cov}% |"
+            echo "| main    | ${main_display} |"
+            echo "| Δ       | ${delta} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "pr_cov=$pr_cov"
+            echo "main_cov=$main_cov"
+            echo "main_display=$main_display"
+            echo "delta=$delta"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post coverage comment
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PR_COV: ${{ steps.delta.outputs.pr_cov }}
+          MAIN_DISPLAY: ${{ steps.delta.outputs.main_display }}
+          DELTA: ${{ steps.delta.outputs.delta }}
+        with:
+          script: |
+            const marker = '<!-- paseri-coverage -->';
+            const body = [
+              marker,
+              '## Coverage',
+              '',
+              '| Branch | Value |',
+              '|--------|-------|',
+              `| This PR | ${process.env.PR_COV}% |`,
+              `| main    | ${process.env.MAIN_DISPLAY} |`,
+              `| Δ       | ${process.env.DELTA} |`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }


### PR DESCRIPTION
- SHA-pin actions; add Dependabot for github-actions.
- Scope GITHUB_TOKEN with workflow- and job-level permissions.
- Gate publish on the release environment and skip cache on that path.
- Move badge updates to a dedicated job using a scoped badges environment.
- Cache main's metrics so PRs post coverage and bundle-size deltas.