### PR TITLE
fix: Clone Date bounds in date().min/max

### DIFF
--- a/paseri-lib/src/schemas/date.test.ts
+++ b/paseri-lib/src/schemas/date.test.ts
@@ -89,6 +89,15 @@ describe('min', () => {
         const branched = modified.max(new Date(2025, 0, 1));
         expect(branched).not.toEqual(modified);
     });
+
+    it('clones the bound value', () => {
+        const bound = new Date(2020, 0, 1);
+        const schema = p.date().min(bound);
+        bound.setFullYear(2030);
+
+        const result = schema.safeParse(new Date(2025, 0, 1));
+        expect(result.ok).toBe(true);
+    });
 });
 
 describe('max', () => {
@@ -133,6 +142,15 @@ describe('max', () => {
         expect(modified).not.toEqual(original);
         const branched = modified.min(new Date(2020, 0, 1));
         expect(branched).not.toEqual(modified);
+    });
+
+    it('clones the bound value', () => {
+        const bound = new Date(2020, 0, 1);
+        const schema = p.date().max(bound);
+        bound.setFullYear(2010);
+
+        const result = schema.safeParse(new Date(2015, 0, 1));
+        expect(result.ok).toBe(true);
     });
 });
 

--- a/paseri-lib/src/schemas/date.ts
+++ b/paseri-lib/src/schemas/date.ts
@@ -64,7 +64,7 @@ class DateSchema extends Schema<Date> {
 
         const cloned = this._clone();
         cloned._checks = cloned._checks || [];
-        cloned._checks.push({ tag: TAG_MIN, param: value, issue: this.issues.TOO_DATED });
+        cloned._checks.push({ tag: TAG_MIN, param: new Date(value.getTime()), issue: this.issues.TOO_DATED });
 
         return cloned;
     }
@@ -75,7 +75,7 @@ class DateSchema extends Schema<Date> {
 
         const cloned = this._clone();
         cloned._checks = cloned._checks || [];
-        cloned._checks.push({ tag: TAG_MAX, param: value, issue: this.issues.TOO_RECENT });
+        cloned._checks.push({ tag: TAG_MAX, param: new Date(value.getTime()), issue: this.issues.TOO_RECENT });
 
         return cloned;
     }


### PR DESCRIPTION
## Summary
- `DateSchema.min(value)` and `.max(value)` previously stored the caller's `Date` reference directly in `_checks`, so mutating it after construction silently moved the bound — leaking the "schemas are immutable" contract that every other constrained schema honors.
- Fix: clone via `new Date(value.getTime())` once at `.min()`/`.max()` construction. Hot `_parse` path is untouched (zero per-parse cost).
- Two new `clones the bound value` tests pin bound-reference immutability for `min` and `max`. They fail on the pre-fix code and pass after the clone.

Other date-shaped schemas (`plainDate`, `plainDateTime`, `zonedDateTime`, `instant`, `plainTime`, `plainYearMonth`, `plainMonthDay`, `duration`) store Temporal values, which are immutable by spec — no fix needed there.

Plan: `.claude/plans/date-bound-immutability-plan.md` (not committed).

## Test plan
- [x] `deno task check` clean
- [x] `deno test -P paseri-lib/src/schemas/date.test.ts` — 7 passed (10 steps), including new `clones the bound value` cases under `min` and `max`
- [x] `deno bench --filter Paseri paseri-lib/bench/date/` — unchanged (bench doesn't exercise `.min()`/`.max()`; the fix is construction-time only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)