### PR TITLE
Release: paseri-lib@1.2.0

### DIFF
--- a/.changeset/lazy-recursion-depth.md
+++ b/.changeset/lazy-recursion-depth.md
@@ -1,5 +1,0 @@
----
-"@vbudovski/paseri": minor
----
-
-Add a `maxDepth` option to `safeParse` / `parse` that caps the nesting depth of recursive input on `lazy()` schemas, preventing attacker-controlled deeply nested values from stack-overflowing the runtime. The default of `1000` is generous and rarely needs changing; deeper input is rejected with a `too_deep` issue. Override per call: `schema.safeParse(data, { maxDepth: 5000 })`.

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vbudovski/paseri
 
+## 1.1.0
+
+### Minor Changes
+
+- 021a7b7: Add a `maxDepth` option to `safeParse` / `parse` that caps the nesting depth of recursive input on `lazy()` schemas, preventing attacker-controlled deeply nested values from stack-overflowing the runtime. The default of `1000` is generous and rarely needs changing; deeper input is rejected with a `too_deep` issue. Override per call: `schema.safeParse(data, { maxDepth: 5000 })`.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@vbudovski/paseri",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "exports": {
     ".": "./src/index.ts",
     "./locales": "./src/locales/index.ts"


### PR DESCRIPTION
## paseri-lib 1.2.0

### Minor Changes

- 8fe88ea: Renamed the published package from `@vbudovski/paseri` to `@paseri/paseri`. Update imports to the new specifier; the `introspect` and `locales` subpaths carry over unchanged (`@paseri/paseri/introspect`, `@paseri/paseri/locales`).

### Patch Changes

- 4dd1bf3: Improve `parse` performance by avoiding an unnecessary allocation and unwrapping of the value.
- 473ba56: Reject empty tuple and object schemas at runtime on top of existing type checks.
- 2d2d2b7: Reject undersized union and empty enum schemas at runtime on top of existing type checks.
- 8c34f00: Invoke `.refine()` / `.chain()` callbacks without a `this` receiver. A non-arrow callback's `this` was previously bound to the internal schema instance (only ever exposing private fields); depending on it was never supported. Arrow callbacks and explicitly-bound functions are unaffected.