### PR TITLE
feature: Split README per workspace member and scope coverage per package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
     environment: badges
     permissions: {}
     steps:
-      - name: Update coverage badge
+      - name: Update paseri-lib coverage badge
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
           gistID: 80548a1b87f9f00fe1ae426ca6a2a517
           filename: vbudovski_paseri_main-coverage.svg
           label: coverage
-          message: ${{ needs.test.outputs.coverage }}%
-          valColorRange: ${{ needs.test.outputs.coverage }}
+          message: ${{ needs.test.outputs.lib_coverage }}%
+          valColorRange: ${{ needs.test.outputs.lib_coverage }}
           minColorRange: 50
           maxColorRange: 90
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ on:
         type: boolean
         default: true
     outputs:
-      coverage:
-        description: "Code coverage percentage from the test run."
-        value: ${{ jobs.unit.outputs.coverage }}
+      lib_coverage:
+        description: "Code coverage percentage for paseri-lib."
+        value: ${{ jobs.unit.outputs.lib_coverage }}
 
 permissions: {}
 
@@ -22,7 +22,7 @@ jobs:
       contents: read
       pull-requests: write
     outputs:
-      coverage: ${{ steps.tests.outputs.CODE_COVERAGE }}
+      lib_coverage: ${{ steps.tests.outputs.LIB_COVERAGE }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -53,38 +53,38 @@ jobs:
         id: tests
         run: |
           deno test -P --doc --coverage
-          echo "CODE_COVERAGE=$(deno coverage | grep "All files" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d '|' -f 3 | xargs)" >> $GITHUB_OUTPUT
+          echo "LIB_COVERAGE=$(deno coverage --include=paseri-lib/src/ | grep "All files" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d '|' -f 3 | xargs)" >> $GITHUB_OUTPUT
 
       - name: Write main metric
         if: github.ref == 'refs/heads/main'
-        run: printf '%s' "${{ steps.tests.outputs.CODE_COVERAGE }}" > main-coverage.txt
+        run: printf '%s' "${{ steps.tests.outputs.LIB_COVERAGE }}" > main-coverage-lib.txt
 
       - name: Save main coverage metric
         if: github.ref == 'refs/heads/main'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: main-coverage.txt
-          key: main-metrics-coverage-${{ github.sha }}
+          path: main-coverage-lib.txt
+          key: main-metrics-coverage-lib-${{ github.sha }}
 
       - name: Restore main coverage metric
         if: github.event_name == 'pull_request'
         id: restore
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: main-coverage.txt
-          key: main-metrics-coverage-${{ github.event.pull_request.base.sha }}
+          path: main-coverage-lib.txt
+          key: main-metrics-coverage-lib-${{ github.event.pull_request.base.sha }}
           restore-keys: |
-            main-metrics-coverage-
+            main-metrics-coverage-lib-
 
       - name: Compute coverage delta
         if: github.event_name == 'pull_request'
         id: delta
         run: |
-          pr_cov="${{ steps.tests.outputs.CODE_COVERAGE }}"
+          pr_cov="${{ steps.tests.outputs.LIB_COVERAGE }}"
           # Strict numeric whitelist on PR value.
           pr_cov=$(printf '%s' "$pr_cov" | tr -cd '0-9.' | head -c 8)
-          if [ -f main-coverage.txt ]; then
-            main_cov=$(tr -cd '0-9.' < main-coverage.txt | head -c 8)
+          if [ -f main-coverage-lib.txt ]; then
+            main_cov=$(tr -cd '0-9.' < main-coverage-lib.txt | head -c 8)
             delta=$(awk -v a="$pr_cov" -v b="$main_cov" 'BEGIN { printf "%+.2f", a - b }')
             main_display="${main_cov}%"
           else

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-paseri-lib/README.md
+[![Release](https://github.com/vbudovski/paseri/actions/workflows/release.yml/badge.svg)](https://github.com/vbudovski/paseri/actions/workflows/release.yml)
+
+---
+
+# Paseri workspace
+
+Deno workspace for [Paseri](https://paseri.dev), a TypeScript parsing and validation library.
+
+## Workspace
+
+- [`paseri-lib`](https://github.com/vbudovski/paseri/tree/main/paseri-lib) &mdash; the validation library, published to
+  JSR as [`@vbudovski/paseri`](https://jsr.io/@vbudovski/paseri).
+- [`paseri-docs`](https://github.com/vbudovski/paseri/tree/main/paseri-docs) &mdash; the
+  [paseri.dev](https://paseri.dev) documentation site, built with [Astro](https://astro.build/) and
+  [Starlight](https://starlight.astro.build/).
+
+## Developer guide
+
+Paseri uses the [Deno](https://deno.com/) runtime rather than Node, and requires Deno 2.7 or later. Packages are
+published to the [JSR registry](https://jsr.io/) only, and publishing is performed automatically by CI.
+
+### Setup
+
+After cloning the repository, be sure you set up the git hooks using the following command:
+
+```shell
+deno task init
+```
+
+### Running tests
+
+```shell
+deno test -P
+```
+
+### Running benchmarks
+
+```shell
+deno bench
+```

--- a/paseri-docs/README.md
+++ b/paseri-docs/README.md
@@ -1,0 +1,41 @@
+# Paseri docs
+
+Source for the [paseri.dev](https://paseri.dev) documentation site. Built with [Astro](https://astro.build/) and
+[Starlight](https://starlight.astro.build/).
+
+## Project layout
+
+- `src/content/docs/` &mdash; documentation pages (`.md` / `.mdx`), organised by URL path.
+- `src/components/` &mdash; Preact components used inside pages (e.g. the playground editor).
+- `src/assets/` &mdash; images and other static assets imported by pages.
+- `src/styles/` &mdash; global and component CSS.
+- `astro.config.ts` &mdash; site config, sidebar definition, and integrations.
+
+## Adding a doc page
+
+Docs are a Starlight content collection. Create an `.md` or `.mdx` file under `src/content/docs/` whose path matches
+the desired URL. The `reference/` section autogenerates from its directory tree; any other section needs an explicit
+entry in the `sidebar` array of `astro.config.ts`.
+
+## Local development
+
+You can preview the documentation by executing the following command from the workspace root:
+
+```shell
+deno task -f paseri-docs dev
+```
+
+Deployment is automatically handled on push to `main`, but you can verify the static build locally using:
+
+```shell
+deno task -f paseri-docs build
+deno task -f paseri-docs preview
+```
+
+## Deployment
+
+[paseri.dev](https://paseri.dev) is auto-deployed by Cloudflare Pages on push to `main`.
+
+---
+
+Part of the [Paseri workspace](https://github.com/vbudovski/paseri).

--- a/paseri-lib/README.md
+++ b/paseri-lib/README.md
@@ -1,4 +1,3 @@
-[![Release](https://github.com/vbudovski/paseri/actions/workflows/release.yml/badge.svg)](https://github.com/vbudovski/paseri/actions/workflows/release.yml)
 [![Coverage](https://gist.githubusercontent.com/vbudovski/80548a1b87f9f00fe1ae426ca6a2a517/raw/vbudovski_paseri_main-coverage.svg)](https://github.com/vbudovski/paseri/actions/workflows/release.yml)
 [![Bundle Size](https://gist.githubusercontent.com/vbudovski/80548a1b87f9f00fe1ae426ca6a2a517/raw/vbudovski_paseri_main-bundlesize.svg)](https://github.com/vbudovski/paseri/actions/workflows/release.yml)
 [![JSR](https://jsr.io/badges/@vbudovski/paseri)](https://jsr.io/@vbudovski/paseri)
@@ -68,35 +67,6 @@ The list may be expanded over time, but for now the objectives are the following
 
 https://paseri.dev
 
-## Developer guide
-
-Paseri uses the [Deno](https://deno.com/) runtime rather than Node, and requires Deno 2.7 or later. Packages are
-published to the [JSR registry](https://jsr.io/) only, and publishing is performed automatically by CI.
-
-* `paseri-lib` contains the sources for the library.
-* `paseri-docs` contains the documentation, built with [Astro](https://astro.build/) and
-  [Starlight](https://starlight.astro.build/).
-
-### Setup
-
-After cloning the repository, be sure you set up the git hooks using the following command:
-
-```shell
-deno task init
-```
-
-### Running tests
-
-```shell
-deno test -P
-```
-
-### Running benchmarks
-
-```shell
-deno bench
-```
-
 ---
 
 [^1]: While higher performance is possible using dynamic code execution (JIT) or ahead-of-time (AOT) compilation, these
@@ -106,3 +76,7 @@ or added build complexity.
 
 [^2]: An [excellent article](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/) on the concept of
 type-driven design.
+
+---
+
+Part of the [Paseri workspace](https://github.com/vbudovski/paseri).


### PR DESCRIPTION
- Replace the symlinked top-level README with a workspace index linking to each member README.
- Narrow the coverage report generation to per-workspace.