### PR TITLE
fix: Set Dependabot commit prefix to an allowed type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: fix


### PR DESCRIPTION
Dependabot's default `build(deps):` commit prefix is rejected by the commitlint gate, whose `type-enum` only permits `feature`/`fix`/`test`/`doc`/`refactor` (see the failed run on #77). This pins Dependabot's prefix to `fix` so dependency-bump PRs pass commit lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)