### PR TITLE
Release: paseri-lib@1.2.0

### DIFF
--- a/.changeset/cool-singers-relax.md
+++ b/.changeset/cool-singers-relax.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Improve `parse` performance by avoiding an unnecessary allocation and unwrapping of the value.

--- a/.changeset/crisp-clowns-double.md
+++ b/.changeset/crisp-clowns-double.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Reject empty tuple and object schemas at runtime on top of existing type checks.

--- a/.changeset/rename-to-paseri-scope.md
+++ b/.changeset/rename-to-paseri-scope.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": minor
----
-
-Renamed the published package from `@vbudovski/paseri` to `@paseri/paseri`. Update imports to the new specifier; the `introspect` and `locales` subpaths carry over unchanged (`@paseri/paseri/introspect`, `@paseri/paseri/locales`).

--- a/.changeset/swift-falcons-soar.md
+++ b/.changeset/swift-falcons-soar.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Reject undersized union and empty enum schemas at runtime on top of existing type checks.

--- a/.changeset/tidy-falcons-rest.md
+++ b/.changeset/tidy-falcons-rest.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Invoke `.refine()` / `.chain()` callbacks without a `this` receiver. A non-arrow callback's `this` was previously bound to the internal schema instance (only ever exposing private fields); depending on it was never supported. Arrow callbacks and explicitly-bound functions are unaffected.

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @paseri/paseri
 
+## 1.2.0
+
+### Minor Changes
+
+- 8fe88ea: Renamed the published package from `@vbudovski/paseri` to `@paseri/paseri`. Update imports to the new specifier; the `introspect` and `locales` subpaths carry over unchanged (`@paseri/paseri/introspect`, `@paseri/paseri/locales`).
+
+### Patch Changes
+
+- 4dd1bf3: Improve `parse` performance by avoiding an unnecessary allocation and unwrapping of the value.
+- 473ba56: Reject empty tuple and object schemas at runtime on top of existing type checks.
+- 2d2d2b7: Reject undersized union and empty enum schemas at runtime on top of existing type checks.
+- 8c34f00: Invoke `.refine()` / `.chain()` callbacks without a `this` receiver. A non-arrow callback's `this` was previously bound to the internal schema instance (only ever exposing private fields); depending on it was never supported. Arrow callbacks and explicitly-bound functions are unaffected.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.2.0

### Minor Changes

- 8fe88ea: Renamed the published package from `@vbudovski/paseri` to `@paseri/paseri`. Update imports to the new specifier; the `introspect` and `locales` subpaths carry over unchanged (`@paseri/paseri/introspect`, `@paseri/paseri/locales`).

### Patch Changes

- 4dd1bf3: Improve `parse` performance by avoiding an unnecessary allocation and unwrapping of the value.
- 473ba56: Reject empty tuple and object schemas at runtime on top of existing type checks.
- 2d2d2b7: Reject undersized union and empty enum schemas at runtime on top of existing type checks.
- 8c34f00: Invoke `.refine()` / `.chain()` callbacks without a `this` receiver. A non-arrow callback's `this` was previously bound to the internal schema instance (only ever exposing private fields); depending on it was never supported. Arrow callbacks and explicitly-bound functions are unaffected.
