### PR TITLE
Release: paseri-lib@1.2.1

### DIFF
--- a/.changeset/proud-otters-jump.md
+++ b/.changeset/proud-otters-jump.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Document the `introspect` subpath: add a module overview with a usage example and JSDoc for each exported IR type (`IR`, `IRGraph`, `SerializedCallback`, and the `*Check` constraint aliases).

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/paseri
 
+## 1.2.1
+
+### Patch Changes
+
+- 80d169e: Document the `introspect` subpath: add a module overview with a usage example and JSDoc for each exported IR type (`IR`, `IRGraph`, `SerializedCallback`, and the `*Check` constraint aliases).
+
 ## 1.2.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.2.1

### Patch Changes

- 80d169e: Document the `introspect` subpath: add a module overview with a usage example and JSDoc for each exported IR type (`IR`, `IRGraph`, `SerializedCallback`, and the `*Check` constraint aliases).