### PR TITLE
fix: Match only open PRs when reusing the release branch

### DIFF
--- a/bin/release.ts
+++ b/bin/release.ts
@@ -71,7 +71,21 @@ async function recreateReleaseBranch(): Promise<void> {
 }
 
 async function findExistingPr(): Promise<string | null> {
-    const { code, stdout } = await capture('gh', ['pr', 'view', RELEASE_BRANCH, '--json', 'url', '--jq', '.url']);
+    // Only an OPEN PR counts as existing. `gh pr view <branch>` also returns
+    // the previous release's MERGED PR (the branch name is reused every
+    // cycle), which we'd then wrongly edit instead of opening a fresh PR.
+    const { code, stdout } = await capture('gh', [
+        'pr',
+        'list',
+        '--head',
+        RELEASE_BRANCH,
+        '--state',
+        'open',
+        '--json',
+        'url',
+        '--jq',
+        '.[0].url // empty',
+    ]);
     if (code !== 0 || stdout.length === 0) {
         return null;
     }


### PR DESCRIPTION
findExistingPr used `gh pr view <branch>`, which also returns the previous release's merged PR (the branch name is reused each cycle). The script then edited that merged PR instead of opening a fresh one, so no release PR was created. List open PRs for the branch instead.