### PR TITLE
Release: paseri-lib@1.4.0, paseri-compiler@0.3.0

### DIFF
--- a/.changeset/aot-emit-perf.md
+++ b/.changeset/aot-emit-perf.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiled validators stay below V8's optimise-size limit (nested object validation outlines into hoisted, deduplicated helpers) and read each entry field once instead of re-loading it per check: ~30% faster invalid-input validation on wide nested schemas, ~34-77% faster valid-input validation on wide objects, and up to ~66% smaller emitted modules.

--- a/.changeset/aot-inline-acyclic-lazy.md
+++ b/.changeset/aot-inline-acyclic-lazy.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": minor
----
-
-Compiled validators inline acyclic `lazy()` targets (forward references and shared subtrees) at their use sites with statically-tracked depth boundaries, instead of emitting named functions and threading depth parameters through the module: ~3.5% faster on valid input for the forward-reference pattern, at some emitted-size cost for multiply-referenced targets.

--- a/.changeset/aot-shape-path-refs.md
+++ b/.changeset/aot-shape-path-refs.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiled validators keep the shape fast path for schemas with lazy (recursive) fields and for containers of strict-mode objects: ~12-18% faster on valid input for the affected schemas, with allocation-free success paths.

--- a/.changeset/ir-cycles.md
+++ b/.changeset/ir-cycles.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": minor
----
-
-`toIR()` graphs now include `cycles` — the named entries that actually participate in a recursion cycle — so consumers can distinguish true recursion from forward references and shared subtrees.

--- a/.changeset/ir-union-discriminator.md
+++ b/.changeset/ir-union-discriminator.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": minor
-"@paseri/compiler": patch
----
-
-Union IR nodes record the discriminator key the runtime selected at construction; the compiler dispatches on the recorded key instead of re-deriving the selection rule. Generated output is unchanged.

--- a/.changeset/jsr-example-fixes.md
+++ b/.changeset/jsr-example-fixes.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-JSR documentation fixes: the landing-page examples now pass a locale to `messages()`, and `toSource` documents the `parse<Name>` export alongside `safeParse<Name>`.

--- a/.changeset/passthrough-unrecognised-keys.md
+++ b/.changeset/passthrough-unrecognised-keys.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Passthrough-mode objects with unrecognised keys parse ~35-40% faster: the parser no longer collects unrecognised keys it never consumes in that mode.

--- a/.changeset/refine-snapshot-annotation.md
+++ b/.changeset/refine-snapshot-annotation.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Generated modules with a refine inside an array, set, map, or record element now pass strict `deno check`: the refine before-snapshot const is explicitly annotated, breaking a loop back-edge inference cycle (TS7022).

--- a/.changeset/temporal-runtime-bounds.md
+++ b/.changeset/temporal-runtime-bounds.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Temporal bound checks are 6-20x faster: Instant and ZonedDateTime bounds compare by precomputed epoch nanoseconds, and Plain* bounds compare by ISO fields when both sides use the iso8601 calendar.

--- a/.changeset/union-default-shape-fix.md
+++ b/.changeset/union-default-shape-fix.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiled validators no longer let a later union member accept input that the runtime resolves by applying an earlier member's default.

--- a/.changeset/union-precheck-dedup-returns.md
+++ b/.changeset/union-precheck-dedup-returns.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Unions on the accumulate path skip their issue machinery when a member shape-matches cleanly. Generated modules no longer carry dead shape helpers or duplicate trailing success returns.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @paseri/compiler
 
+## 0.3.0
+
+### Minor Changes
+
+- 58ecc55: Compiled validators inline acyclic `lazy()` targets (forward references and shared subtrees) at their use sites with statically-tracked depth boundaries, instead of emitting named functions and threading depth parameters through the module: ~3.5% faster on valid input for the forward-reference pattern, at some emitted-size cost for multiply-referenced targets.
+
+### Patch Changes
+
+- 4109c4d: Compiled validators stay below V8's optimise-size limit (nested object validation outlines into hoisted, deduplicated helpers) and read each entry field once instead of re-loading it per check: ~30% faster invalid-input validation on wide nested schemas, ~34-77% faster valid-input validation on wide objects, and up to ~66% smaller emitted modules.
+- 213829d: Compiled validators keep the shape fast path for schemas with lazy (recursive) fields and for containers of strict-mode objects: ~12-18% faster on valid input for the affected schemas, with allocation-free success paths.
+- ab87d72: Union IR nodes record the discriminator key the runtime selected at construction; the compiler dispatches on the recorded key instead of re-deriving the selection rule. Generated output is unchanged.
+- ecb54d3: JSR documentation fixes: the landing-page examples now pass a locale to `messages()`, and `toSource` documents the `parse<Name>` export alongside `safeParse<Name>`.
+- 5d28a82: Generated modules with a refine inside an array, set, map, or record element now pass strict `deno check`: the refine before-snapshot const is explicitly annotated, breaking a loop back-edge inference cycle (TS7022).
+- 9b42484: Compiled validators no longer let a later union member accept input that the runtime resolves by applying an earlier member's default.
+- 9b42484: Unions on the accumulate path skip their issue machinery when a member shape-matches cleanly. Generated modules no longer carry dead shape helpers or duplicate trailing success returns.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @paseri/paseri
 
+## 1.4.0
+
+### Minor Changes
+
+- 58ecc55: `toIR()` graphs now include `cycles` — the named entries that actually participate in a recursion cycle — so consumers can distinguish true recursion from forward references and shared subtrees.
+- ab87d72: Union IR nodes record the discriminator key the runtime selected at construction; the compiler dispatches on the recorded key instead of re-deriving the selection rule. Generated output is unchanged.
+
+### Patch Changes
+
+- ecb54d3: JSR documentation fixes: the landing-page examples now pass a locale to `messages()`, and `toSource` documents the `parse<Name>` export alongside `safeParse<Name>`.
+- e472338: Passthrough-mode objects with unrecognised keys parse ~35-40% faster: the parser no longer collects unrecognised keys it never consumes in that mode.
+- 33a05e0: Temporal bound checks are 6-20x faster: Instant and ZonedDateTime bounds compare by precomputed epoch nanoseconds, and Plain\* bounds compare by ISO fields when both sides use the iso8601 calendar.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.4.0

### Minor Changes

- 58ecc55: `toIR()` graphs now include `cycles` — the named entries that actually participate in a recursion cycle — so consumers can distinguish true recursion from forward references and shared subtrees.
- ab87d72: Union IR nodes record the discriminator key the runtime selected at construction; the compiler dispatches on the recorded key instead of re-deriving the selection rule. Generated output is unchanged.

### Patch Changes

- ecb54d3: JSR documentation fixes: the landing-page examples now pass a locale to `messages()`, and `toSource` documents the `parse<Name>` export alongside `safeParse<Name>`.
- e472338: Passthrough-mode objects with unrecognised keys parse ~35-40% faster: the parser no longer collects unrecognised keys it never consumes in that mode.
- 33a05e0: Temporal bound checks are 6-20x faster: Instant and ZonedDateTime bounds compare by precomputed epoch nanoseconds, and Plain\* bounds compare by ISO fields when both sides use the iso8601 calendar.

## paseri-compiler 0.3.0

### Minor Changes

- 58ecc55: Compiled validators inline acyclic `lazy()` targets (forward references and shared subtrees) at their use sites with statically-tracked depth boundaries, instead of emitting named functions and threading depth parameters through the module: ~3.5% faster on valid input for the forward-reference pattern, at some emitted-size cost for multiply-referenced targets.

### Patch Changes

- 4109c4d: Compiled validators stay below V8's optimise-size limit (nested object validation outlines into hoisted, deduplicated helpers) and read each entry field once instead of re-loading it per check: ~30% faster invalid-input validation on wide nested schemas, ~34-77% faster valid-input validation on wide objects, and up to ~66% smaller emitted modules.
- 213829d: Compiled validators keep the shape fast path for schemas with lazy (recursive) fields and for containers of strict-mode objects: ~12-18% faster on valid input for the affected schemas, with allocation-free success paths.
- ab87d72: Union IR nodes record the discriminator key the runtime selected at construction; the compiler dispatches on the recorded key instead of re-deriving the selection rule. Generated output is unchanged.
- ecb54d3: JSR documentation fixes: the landing-page examples now pass a locale to `messages()`, and `toSource` documents the `parse<Name>` export alongside `safeParse<Name>`.
- 5d28a82: Generated modules with a refine inside an array, set, map, or record element now pass strict `deno check`: the refine before-snapshot const is explicitly annotated, breaking a loop back-edge inference cycle (TS7022).
- 9b42484: Compiled validators no longer let a later union member accept input that the runtime resolves by applying an earlier member's default.
- 9b42484: Unions on the accumulate path skip their issue machinery when a member shape-matches cleanly. Generated modules no longer carry dead shape helpers or duplicate trailing success returns.