### PR TITLE
fix: Pin CI to Deno 2.8.2

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
-          deno-version: "^2.7.14"
+          deno-version: "2.8.2"
 
       - name: Calculate bundle size
         id: bundle

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
-          deno-version: "^2.7.14"
+          deno-version: "2.8.2"
 
       - name: Get pnpm store directory
         id: deno-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
-          deno-version: "^2.7.14"
+          deno-version: "2.8.2"
 
       - name: Get pnpm store directory
         id: deno-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
-          deno-version: "^2.7.14"
+          deno-version: "2.8.2"
 
       - run: deno publish
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
         with:
-          deno-version: "^2.7.14"
+          deno-version: "2.8.2"
 
       - name: Get DENO_DIR
         if: ${{ inputs.use_cache }}


### PR DESCRIPTION
Deno 2.8.3 injects the documented module's exports as a named import into each doc-test fence; paseri-lib's reserved-word export names (enum, null) make that line unparseable (TS1003), failing every PR. Pin until denoland/deno#35177 is fixed.