### PR TITLE
Release: paseri-lib@1.5.0, paseri-compiler@0.4.0

### DIFF
--- a/.changeset/aot-discriminated-union-outline.md
+++ b/.changeset/aot-discriminated-union-outline.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Discriminated union members are outlined into hoisted helpers, keeping wide unions below V8's optimise-size limit: ~36% faster invalid-input validation on a 24-variant union.

--- a/.changeset/derived-shape-map-lookup.md
+++ b/.changeset/derived-shape-map-lookup.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Derived object schemas (merge/pick/omit/partial/required) parse ~30% faster: field lookups now go through a Map, sidestepping V8's slower keyed loads on runtime-assembled shapes. Literal-shaped schemas are unchanged.

--- a/.changeset/plain-object-fast-accept.md
+++ b/.changeset/plain-object-fast-accept.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": minor
-"@paseri/compiler": minor
----
-
-`isPlainObject` accepts `constructor === Object` before the reflective prototype check: ~10% faster object and record validation at runtime, ~28% for compiled validators. Objects whose `constructor` resolves to `Object` through a longer prototype chain (e.g. `Object.create({ ... })`) are now treated as plain; such values only arise from in-process prototype manipulation, never from serialised input.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @paseri/compiler
 
+## 0.4.0
+
+### Minor Changes
+
+- 47b2a15: `isPlainObject` accepts `constructor === Object` before the reflective prototype check: ~10% faster object and record validation at runtime, ~28% for compiled validators. Objects whose `constructor` resolves to `Object` through a longer prototype chain (e.g. `Object.create({ ... })`) are now treated as plain; such values only arise from in-process prototype manipulation, never from serialised input.
+
+### Patch Changes
+
+- d4da16f: Discriminated union members are outlined into hoisted helpers, keeping wide unions below V8's optimise-size limit: ~36% faster invalid-input validation on a 24-variant union.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @paseri/paseri
 
+## 1.5.0
+
+### Minor Changes
+
+- 47b2a15: `isPlainObject` accepts `constructor === Object` before the reflective prototype check: ~10% faster object and record validation at runtime, ~28% for compiled validators. Objects whose `constructor` resolves to `Object` through a longer prototype chain (e.g. `Object.create({ ... })`) are now treated as plain; such values only arise from in-process prototype manipulation, never from serialised input.
+
+### Patch Changes
+
+- c042555: Derived object schemas (merge/pick/omit/partial/required) parse ~30% faster: field lookups now go through a Map, sidestepping V8's slower keyed loads on runtime-assembled shapes. Literal-shaped schemas are unchanged.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.5.0

### Minor Changes

- 47b2a15: `isPlainObject` accepts `constructor === Object` before the reflective prototype check: ~10% faster object and record validation at runtime, ~28% for compiled validators. Objects whose `constructor` resolves to `Object` through a longer prototype chain (e.g. `Object.create({ ... })`) are now treated as plain; such values only arise from in-process prototype manipulation, never from serialised input.

### Patch Changes

- c042555: Derived object schemas (merge/pick/omit/partial/required) parse ~30% faster: field lookups now go through a Map, sidestepping V8's slower keyed loads on runtime-assembled shapes. Literal-shaped schemas are unchanged.

## paseri-compiler 0.4.0

### Minor Changes

- 47b2a15: `isPlainObject` accepts `constructor === Object` before the reflective prototype check: ~10% faster object and record validation at runtime, ~28% for compiled validators. Objects whose `constructor` resolves to `Object` through a longer prototype chain (e.g. `Object.create({ ... })`) are now treated as plain; such values only arise from in-process prototype manipulation, never from serialised input.

### Patch Changes

- d4da16f: Discriminated union members are outlined into hoisted helpers, keeping wide unions below V8's optimise-size limit: ~36% faster invalid-input validation on a 24-variant union.