### PR TITLE
fix: Gate changesets on all publishable members

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -16,7 +16,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Require changeset for paseri-lib/src changes
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        with:
+          deno-version: "2.8.2"
+
+      - name: Require changeset for publishable src changes
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -28,11 +33,15 @@ jobs:
           git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null
           git rev-parse --verify "$HEAD_SHA^{commit}" >/dev/null
 
-          src_changes=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- paseri-lib/src \
+          # Watch each publishable member's src/ (the set `deno publish` ships),
+          # so a new package is gated without editing this workflow.
+          mapfile -t src_dirs < <(deno eval 'const { listPublishableMembers } = await import("./bin/lib/workspace.ts"); for (const m of await listPublishableMembers(new URL("file://" + Deno.cwd() + "/"))) console.log(m.dir + "/src");')
+
+          src_changes=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "${src_dirs[@]}" \
             | grep -v '\.test\.ts$' || true)
 
           if [ -z "$src_changes" ]; then
-            echo "No paseri-lib/src changes — changeset not required."
+            echo "No publishable src changes — changeset not required."
             exit 0
           fi
 
@@ -47,7 +56,7 @@ jobs:
           fi
 
           {
-            echo "::error::This PR modifies paseri-lib/src/** but adds no changeset."
+            echo "::error::This PR modifies a publishable package's src/** but adds no changeset."
             echo "Run 'deno task changeset' locally, commit the generated .changeset/*.md, and push."
             echo ""
             echo "Touched src files:"


### PR DESCRIPTION
The check only watched paseri-lib/src, so a paseri-compiler/src change could merge without a changeset. Derive the watched dirs from listPublishableMembers so every publishable package is gated.