### PR TITLE
Release: paseri-compiler@0.4.1

### DIFF
--- a/.changeset/aot-strip-always-copy.md
+++ b/.changeset/aot-strip-always-copy.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Strip-mode object validators build their output inline from the validated fields (required keys as a static-key literal, optionals when present) instead of scanning for extra keys and rebuilding on the slow path. ~54% faster on clean input, ~84% when extra keys are present. The returned object is now always a fresh copy.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.4.1
+
+### Patch Changes
+
+- e66483a: Strip-mode object validators build their output inline from the validated fields (required keys as a static-key literal, optionals when present) instead of scanning for extra keys and rebuilding on the slow path. ~54% faster on clean input, ~84% when extra keys are present. The returned object is now always a fresh copy.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## paseri-compiler 0.4.1

### Patch Changes

- e66483a: Strip-mode object validators build their output inline from the validated fields (required keys as a static-key literal, optionals when present) instead of scanning for extra keys and rebuilding on the slow path. ~54% faster on clean input, ~84% when extra keys are present. The returned object is now always a fresh copy.