### PR TITLE
Release: paseri-vite-plugin@0.1.0

### DIFF
--- a/.changeset/vite-plugin-initial-release.md
+++ b/.changeset/vite-plugin-initial-release.md
@@ -1,5 +1,0 @@
----
-"@paseri/vite-plugin": minor
----
-
-Initial release. Vite plugin that AOT-compiles Paseri schemas at build time.

--- a/paseri-vite-plugin/CHANGELOG.md
+++ b/paseri-vite-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @paseri/vite-plugin
+
+## 0.1.0
+
+### Minor Changes
+
+- ab571fa: Initial release. Vite plugin that AOT-compiles Paseri schemas at build time.

--- a/paseri-vite-plugin/deno.json
+++ b/paseri-vite-plugin/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/vite-plugin",
   "license": "MIT",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Vite plugin that AOT-compiles Paseri schemas at build time.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## paseri-vite-plugin 0.1.0

### Minor Changes

- ab571fa: Initial release. Vite plugin that AOT-compiles Paseri schemas at build time.