### PR TITLE
Release: paseri-lib@1.6.0, paseri-compiler@0.5.0

### DIFF
--- a/.changeset/generated-record-cast-unknown.md
+++ b/.changeset/generated-record-cast-unknown.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Emit `unknown` instead of `any` as the element type in generated record casts.

--- a/.changeset/infer-unknown-not-empty-object.md
+++ b/.changeset/infer-unknown-not-empty-object.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Fix `Infer` returning `{}` instead of `unknown` for `unknown` schemas.

--- a/.changeset/record-key-property-key.md
+++ b/.changeset/record-key-property-key.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Emit `Record<PropertyKey, V>` for compiled record schemas, matching the runtime's `Infer`.

--- a/.changeset/union-literal-set-optimisation.md
+++ b/.changeset/union-literal-set-optimisation.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": minor
-"@paseri/compiler": minor
----
-
-Optimise all-literal unions (`p.union(p.literal(…), …)`) with an O(1) `Set` membership check, matching `p.enum`. Invalid values now report a single `invalid_enum_value` issue instead of a per-member error tree.

--- a/.changeset/wrapper-inner-subtype-preservation.md
+++ b/.changeset/wrapper-inner-subtype-preservation.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": minor
----
-
-Preserve the inner schema's concrete type through `optional()` and `refine()`: `required()` recovers the original subclass instead of the abstract base, and `Infer` treats an `optional().refine(...)` field as an optional key.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @paseri/compiler
 
+## 0.5.0
+
+### Minor Changes
+
+- a6a9545: Optimise all-literal unions (`p.union(p.literal(…), …)`) with an O(1) `Set` membership check, matching `p.enum`. Invalid values now report a single `invalid_enum_value` issue instead of a per-member error tree.
+
+### Patch Changes
+
+- 9f6052c: Emit `unknown` instead of `any` as the element type in generated record casts.
+- 4d02d3e: Emit `Record<PropertyKey, V>` for compiled record schemas, matching the runtime's `Infer`.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @paseri/paseri
 
+## 1.6.0
+
+### Minor Changes
+
+- a6a9545: Optimise all-literal unions (`p.union(p.literal(…), …)`) with an O(1) `Set` membership check, matching `p.enum`. Invalid values now report a single `invalid_enum_value` issue instead of a per-member error tree.
+- 9b477cc: Preserve the inner schema's concrete type through `optional()` and `refine()`: `required()` recovers the original subclass instead of the abstract base, and `Infer` treats an `optional().refine(...)` field as an optional key.
+
+### Patch Changes
+
+- 99a734f: Fix `Infer` returning `{}` instead of `unknown` for `unknown` schemas.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.6.0

### Minor Changes

- a6a9545: Optimise all-literal unions (`p.union(p.literal(…), …)`) with an O(1) `Set` membership check, matching `p.enum`. Invalid values now report a single `invalid_enum_value` issue instead of a per-member error tree.
- 9b477cc: Preserve the inner schema's concrete type through `optional()` and `refine()`: `required()` recovers the original subclass instead of the abstract base, and `Infer` treats an `optional().refine(...)` field as an optional key.

### Patch Changes

- 99a734f: Fix `Infer` returning `{}` instead of `unknown` for `unknown` schemas.

## paseri-compiler 0.5.0

### Minor Changes

- a6a9545: Optimise all-literal unions (`p.union(p.literal(…), …)`) with an O(1) `Set` membership check, matching `p.enum`. Invalid values now report a single `invalid_enum_value` issue instead of a per-member error tree.

### Patch Changes

- 9f6052c: Emit `unknown` instead of `any` as the element type in generated record casts.
- 4d02d3e: Emit `Record<PropertyKey, V>` for compiled record schemas, matching the runtime's `Infer`.