### PR TITLE
Release: paseri-compiler@0.5.1

### DIFF
--- a/.changeset/aot-strip-reconstruction.md
+++ b/.changeset/aot-strip-reconstruction.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Speed up strip-mode objects in generated validators: nested strip objects, and strip objects with defaults, are rebuilt as a static-key literal that drops unknown keys by construction instead of scanning and bailing to the slow path. Output is unchanged; inputs carrying extra keys are markedly faster.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.5.1
+
+### Patch Changes
+
+- 2ac1c44: Speed up strip-mode objects in generated validators: nested strip objects, and strip objects with defaults, are rebuilt as a static-key literal that drops unknown keys by construction instead of scanning and bailing to the slow path. Output is unchanged; inputs carrying extra keys are markedly faster.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## paseri-compiler 0.5.1

### Patch Changes

- 2ac1c44: Speed up strip-mode objects in generated validators: nested strip objects, and strip objects with defaults, are rebuilt as a static-key literal that drops unknown keys by construction instead of scanning and bailing to the slow path. Output is unchanged; inputs carrying extra keys are markedly faster.