### PR TITLE
Release: paseri-lib@1.7.0, paseri-compiler@0.6.0

### DIFF
--- a/.changeset/string-time-timezone.md
+++ b/.changeset/string-time-timezone.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": minor
----
-
-Add `offset` and `local` options to `string().time()`, matching `string().datetime()`. `local` defaults to `true`, so `time()` accepts bare `hh:mm:ss` or a trailing `Z`; `offset: true` also accepts `±hh:mm`, and `local: false` requires a timezone designator.

--- a/.changeset/string-url.md
+++ b/.changeset/string-url.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": minor
-"@paseri/compiler": minor
----
-
-Add `string().url()`, validating URLs with `URL.canParse` (the WHATWG parser), so it accepts any valid URL of any scheme.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.6.0
+
+### Minor Changes
+
+- d8476d9: Add `string().url()`, validating URLs with `URL.canParse` (the WHATWG parser), so it accepts any valid URL of any scheme.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @paseri/paseri
 
+## 1.7.0
+
+### Minor Changes
+
+- b3c02ae: Add `offset` and `local` options to `string().time()`, matching `string().datetime()`. `local` defaults to `true`, so `time()` accepts bare `hh:mm:ss` or a trailing `Z`; `offset: true` also accepts `±hh:mm`, and `local: false` requires a timezone designator.
+- d8476d9: Add `string().url()`, validating URLs with `URL.canParse` (the WHATWG parser), so it accepts any valid URL of any scheme.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.7.0

### Minor Changes

- b3c02ae: Add `offset` and `local` options to `string().time()`, matching `string().datetime()`. `local` defaults to `true`, so `time()` accepts bare `hh:mm:ss` or a trailing `Z`; `offset: true` also accepts `±hh:mm`, and `local: false` requires a timezone designator.
- d8476d9: Add `string().url()`, validating URLs with `URL.canParse` (the WHATWG parser), so it accepts any valid URL of any scheme.

## paseri-compiler 0.6.0

### Minor Changes

- d8476d9: Add `string().url()`, validating URLs with `URL.canParse` (the WHATWG parser), so it accepts any valid URL of any scheme.