### PR TITLE
Release: paseri-lib@1.9.0, paseri-compiler@0.7.1

### DIFF
--- a/.changeset/aot-date-accumulate-short-circuit.md
+++ b/.changeset/aot-date-accumulate-short-circuit.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Fix the compiled date validator reporting a bound leaf (`too_dated` / `too_recent`) alongside `invalid_date` for a `min`/`max`-constrained date nested in a container. The invalid-date guard now short-circuits the bound checks, matching the runtime.

--- a/.changeset/aot-maxdepth-guard-unconditional.md
+++ b/.changeset/aot-maxdepth-guard-unconditional.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-`safeParse` / `parse` on a compiled schema now reject an invalid `maxDepth` (e.g. `0` or `NaN`) by throwing `maxDepth must be a positive integer.`, matching the runtime. Some generated validators previously accepted it silently.

--- a/.changeset/contradictory-bounds-throw.md
+++ b/.changeset/contradictory-bounds-throw.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": minor
----
-
-Contradictory bounds now throw at construction instead of producing a schema that rejects every input. `p.string().min(5).max(3)`, `p.number().gte(5).lte(3)`, and the equivalents on `array`, `set`, `map`, `bigint`, `date`, and the Temporal schemas throw immediately (e.g. `Minimum length must not exceed maximum length.`). Equal bounds such as `p.number().gte(5).lte(5)` remain valid.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @paseri/compiler
 
+## 0.7.1
+
+### Patch Changes
+
+- be87b16: Fix the compiled date validator reporting a bound leaf (`too_dated` / `too_recent`) alongside `invalid_date` for a `min`/`max`-constrained date nested in a container. The invalid-date guard now short-circuits the bound checks, matching the runtime.
+- 0593d48: `safeParse` / `parse` on a compiled schema now reject an invalid `maxDepth` (e.g. `0` or `NaN`) by throwing `maxDepth must be a positive integer.`, matching the runtime. Some generated validators previously accepted it silently.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/paseri
 
+## 1.9.0
+
+### Minor Changes
+
+- f020ab6: Contradictory bounds now throw at construction instead of producing a schema that rejects every input. `p.string().min(5).max(3)`, `p.number().gte(5).lte(3)`, and the equivalents on `array`, `set`, `map`, `bigint`, `date`, and the Temporal schemas throw immediately (e.g. `Minimum length must not exceed maximum length.`). Equal bounds such as `p.number().gte(5).lte(5)` remain valid.
+
 ## 1.8.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.9.0

### Minor Changes

- f020ab6: Contradictory bounds now throw at construction instead of producing a schema that rejects every input. `p.string().min(5).max(3)`, `p.number().gte(5).lte(3)`, and the equivalents on `array`, `set`, `map`, `bigint`, `date`, and the Temporal schemas throw immediately (e.g. `Minimum length must not exceed maximum length.`). Equal bounds such as `p.number().gte(5).lte(5)` remain valid.

## paseri-compiler 0.7.1

### Patch Changes

- be87b16: Fix the compiled date validator reporting a bound leaf (`too_dated` / `too_recent`) alongside `invalid_date` for a `min`/`max`-constrained date nested in a container. The invalid-date guard now short-circuits the bound checks, matching the runtime.
- 0593d48: `safeParse` / `parse` on a compiled schema now reject an invalid `maxDepth` (e.g. `0` or `NaN`) by throwing `maxDepth must be a positive integer.`, matching the runtime. Some generated validators previously accepted it silently.