### PR TITLE
Release: paseri-lib@1.9.1, paseri-compiler@0.7.2

### DIFF
--- a/.changeset/aot-default-undefined-output-type.md
+++ b/.changeset/aot-default-undefined-output-type.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Fix the compiled result type of a `default` whose inner schema still admits `undefined` (e.g. `p.union(p.string(), p.undefined()).optional().default('x')`): `safeParse`/`parse` now report `string | undefined` instead of `string`, matching the runtime's `Infer`.

--- a/.changeset/string-length-contradictory-bounds.md
+++ b/.changeset/string-length-contradictory-bounds.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().length(n)` now throws `Minimum length must not exceed maximum length.` when the fixed length contradicts an existing `min`/`max` bound (e.g. `p.string().min(5).length(3)`), matching `string().min(5).max(3)` and the other bounded schemas. Previously this path silently built a schema that rejects every input.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.7.2
+
+### Patch Changes
+
+- c91b419: Fix the compiled result type of a `default` whose inner schema still admits `undefined` (e.g. `p.union(p.string(), p.undefined()).optional().default('x')`): `safeParse`/`parse` now report `string | undefined` instead of `string`, matching the runtime's `Infer`.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/paseri
 
+## 1.9.1
+
+### Patch Changes
+
+- 8513b4b: `p.string().length(n)` now throws `Minimum length must not exceed maximum length.` when the fixed length contradicts an existing `min`/`max` bound (e.g. `p.string().min(5).length(3)`), matching `string().min(5).max(3)` and the other bounded schemas. Previously this path silently built a schema that rejects every input.
+
 ## 1.9.0
 
 ### Minor Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## paseri-lib 1.9.1

### Patch Changes

- 8513b4b: `p.string().length(n)` now throws `Minimum length must not exceed maximum length.` when the fixed length contradicts an existing `min`/`max` bound (e.g. `p.string().min(5).length(3)`), matching `string().min(5).max(3)` and the other bounded schemas. Previously this path silently built a schema that rejects every input.

## paseri-compiler 0.7.2

### Patch Changes

- c91b419: Fix the compiled result type of a `default` whose inner schema still admits `undefined` (e.g. `p.union(p.string(), p.undefined()).optional().default('x')`): `safeParse`/`parse` now report `string | undefined` instead of `string`, matching the runtime's `Infer`.