### PR TITLE
fix: Use JSR package name in release tags

### DIFF
--- a/bin/post-publish.ts
+++ b/bin/post-publish.ts
@@ -97,7 +97,7 @@ async function main(): Promise<void> {
     }
 
     for (const member of members) {
-        const tag = `${member.dir}@v${member.version}`;
+        const tag = `${member.name}@${member.version}`;
 
         if (await tagExists(tag)) {
             console.log(`Tag ${tag} already exists; skipping tag creation.`);

--- a/bin/release.ts
+++ b/bin/release.ts
@@ -101,13 +101,13 @@ async function buildPrBody(changed: PublishableMember[]): Promise<string> {
     const sections: string[] = [];
     for (const member of changed) {
         const notes = await readLatestChangelogEntry(member);
-        sections.push(`## ${member.dir} ${member.version}\n\n${notes}`);
+        sections.push(`## ${member.name} ${member.version}\n\n${notes}`);
     }
     return sections.join('\n\n');
 }
 
 function buildPrTitle(changed: PublishableMember[]): string {
-    return `Release: ${changed.map((m) => `${m.dir}@${m.version}`).join(', ')}`;
+    return `Release: ${changed.map((m) => `${m.name}@${m.version}`).join(', ')}`;
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
Tags used the workspace directory name (paseri-lib@v0.5.0) rather than the published identity (@paseri/paseri@0.5.0), and carried a redundant `v`. Switch to the member's name@version, matching changesets' own tag format. The release-PR heading and title get the same fix.