### PR TITLE
Release: @paseri/paseri@1.9.2

### DIFF
--- a/.changeset/number-infinity-bound-contradictions.md
+++ b/.changeset/number-infinity-bound-contradictions.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.number()` bound contradictions that hinge on a ±Infinity bound now throw `Lower bound must not exceed upper bound.` at construction (e.g. `p.number().gte(-Infinity).lt(-Infinity)`), matching the finite cases. Previously they silently built a schema that rejects every input. Single-value intervals such as `p.number().lte(Infinity).gte(Infinity)` remain valid.

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/paseri
 
+## 1.9.2
+
+### Patch Changes
+
+- ff2791c: `p.number()` bound contradictions that hinge on a ±Infinity bound now throw `Lower bound must not exceed upper bound.` at construction (e.g. `p.number().gte(-Infinity).lt(-Infinity)`), matching the finite cases. Previously they silently built a schema that rejects every input. Single-value intervals such as `p.number().lte(Infinity).gte(Infinity)` remain valid.
+
 ## 1.9.1
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## @paseri/paseri 1.9.2

### Patch Changes

- ff2791c: `p.number()` bound contradictions that hinge on a ±Infinity bound now throw `Lower bound must not exceed upper bound.` at construction (e.g. `p.number().gte(-Infinity).lt(-Infinity)`), matching the finite cases. Previously they silently built a schema that rejects every input. Single-value intervals such as `p.number().lte(Infinity).gte(Infinity)` remain valid.