### PR TITLE
test: Pin Temporal ISO comparison ladder rungs

### DIFF
--- a/paseri-lib/src/schemas/plainDate.test.ts
+++ b/paseri-lib/src/schemas/plainDate.test.ts
@@ -31,6 +31,19 @@ const plainDateArb = fc
     })
     .map(({ year, month, day, calendar }) => Temporal.PlainDate.from({ year, month, day }).withCalendar(calendar));
 
+// Both-ISO [bound, value] pairs walking the ISO fast-path comparison ladder: each rung (year, month, day)
+// differs above and below, plus an all-fields-equal pair for the tie terminal. Independent random draws never
+// share a field prefix, so these pin every rung directly.
+const ladderExamples: [Temporal.PlainDate, Temporal.PlainDate][] = [
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2019-06-15')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2021-06-15')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2020-05-15')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2020-07-15')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2020-06-14')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2020-06-16')],
+    [Temporal.PlainDate.from('2020-06-15'), Temporal.PlainDate.from('2020-06-15')],
+];
+
 it('accepts valid types', () => {
     const schema = p.plainDate();
 
@@ -95,6 +108,7 @@ describe('min', () => {
                         Temporal.PlainDate.from('2020-01-01'),
                         Temporal.PlainDate.from('2020-01-01').withCalendar('japanese'),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );
@@ -135,6 +149,7 @@ describe('max', () => {
                         Temporal.PlainDate.from('2020-01-01'),
                         Temporal.PlainDate.from('2020-01-01').withCalendar('japanese'),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );

--- a/paseri-lib/src/schemas/plainDateTime.test.ts
+++ b/paseri-lib/src/schemas/plainDateTime.test.ts
@@ -37,6 +37,88 @@ const plainDateTimeArb = fc
     })
     .map(({ calendar, ...parts }) => Temporal.PlainDateTime.from(parts).withCalendar(calendar));
 
+// Both-ISO [bound, value] pairs walking the ISO fast-path comparison ladder: each rung (year through
+// nanosecond) differs above and below, plus an all-fields-equal pair for the tie terminal. Independent random
+// draws never share a field prefix, so these pin every rung directly.
+const ladderExamples: [Temporal.PlainDateTime, Temporal.PlainDateTime][] = [
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2019-06-15T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2021-06-15T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-05-15T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-07-15T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-14T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-16T12:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T11:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T13:30:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:29:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:31:30.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:29.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:31.500500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.499500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.501500500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500499500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500501500'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500499'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500501'),
+    ],
+    [
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+        Temporal.PlainDateTime.from('2020-06-15T12:30:30.500500500'),
+    ],
+];
+
 it('accepts valid types', () => {
     const schema = p.plainDateTime();
 
@@ -98,6 +180,7 @@ describe('min', () => {
                         Temporal.PlainDateTime.from('2020-01-01T00:00:00'),
                         Temporal.PlainDateTime.from('2020-01-01T00:00:00').withCalendar('japanese'),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );
@@ -140,6 +223,7 @@ describe('max', () => {
                         Temporal.PlainDateTime.from('2020-01-01T00:00:00'),
                         Temporal.PlainDateTime.from('2020-01-01T00:00:00').withCalendar('japanese'),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );

--- a/paseri-lib/src/schemas/plainTime.test.ts
+++ b/paseri-lib/src/schemas/plainTime.test.ts
@@ -17,6 +17,24 @@ const plainTimeArb = fc
     })
     .map((fields) => Temporal.PlainTime.from(fields));
 
+// [bound, value] pairs equal in every higher field and differing at exactly one rung of the field-compare
+// ladder, above and below. Independent random draws never share a field prefix, so these pin each rung (hour
+// through nanosecond) directly.
+const ladderExamples: [Temporal.PlainTime, Temporal.PlainTime][] = [
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('11:30:30.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('13:30:30.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:29:30.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:31:30.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:29.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:31.500500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.499500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.501500500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.500499500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.500501500')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.500500499')],
+    [Temporal.PlainTime.from('12:30:30.500500500'), Temporal.PlainTime.from('12:30:30.500500501')],
+];
+
 it('accepts valid types', () => {
     const schema = p.plainTime();
 
@@ -72,7 +90,7 @@ describe('min', () => {
             }),
             // Seed the exact-boundary case (value equal to the bound): it alone distinguishes an inclusive bound from
             // an exclusive one, and random nanosecond-resolution times never land on it.
-            { examples: [[boundary, Temporal.PlainTime.from('12:00:00')]] },
+            { examples: [[boundary, Temporal.PlainTime.from('12:00:00')], ...ladderExamples] },
         );
     });
 
@@ -107,7 +125,7 @@ describe('max', () => {
                     }
                 }
             }),
-            { examples: [[boundary, Temporal.PlainTime.from('12:00:00')]] },
+            { examples: [[boundary, Temporal.PlainTime.from('12:00:00')], ...ladderExamples] },
         );
     });
 

--- a/paseri-lib/src/schemas/plainYearMonth.test.ts
+++ b/paseri-lib/src/schemas/plainYearMonth.test.ts
@@ -32,6 +32,17 @@ const plainYearMonthArb = fc
         Temporal.PlainDate.from({ year, month, day: 1 }).withCalendar(calendar).toPlainYearMonth(),
     );
 
+// Both-ISO [bound, value] pairs walking the ISO fast-path comparison ladder: each rung (year, month) differs
+// above and below, plus an all-fields-equal pair for the tie terminal. Independent random draws never share a
+// field prefix, so these pin every rung directly.
+const ladderExamples: [Temporal.PlainYearMonth, Temporal.PlainYearMonth][] = [
+    [Temporal.PlainYearMonth.from('2020-06'), Temporal.PlainYearMonth.from('2019-06')],
+    [Temporal.PlainYearMonth.from('2020-06'), Temporal.PlainYearMonth.from('2021-06')],
+    [Temporal.PlainYearMonth.from('2020-06'), Temporal.PlainYearMonth.from('2020-05')],
+    [Temporal.PlainYearMonth.from('2020-06'), Temporal.PlainYearMonth.from('2020-07')],
+    [Temporal.PlainYearMonth.from('2020-06'), Temporal.PlainYearMonth.from('2020-06')],
+];
+
 it('accepts valid types', () => {
     const schema = p.plainYearMonth();
 
@@ -93,6 +104,7 @@ describe('min', () => {
                         Temporal.PlainYearMonth.from('2020-01'),
                         Temporal.PlainDate.from('2020-01-01').withCalendar('japanese').toPlainYearMonth(),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );
@@ -135,6 +147,7 @@ describe('max', () => {
                         Temporal.PlainYearMonth.from('2020-01'),
                         Temporal.PlainDate.from('2020-01-01').withCalendar('japanese').toPlainYearMonth(),
                     ],
+                    ...ladderExamples,
                 ],
             },
         );


### PR DESCRIPTION
The min/max property tests draw bound and value independently, so two iso8601 values almost never share a field prefix: only the first ladder rung was reached (flakily — flipping line coverage by fast-check seed), and the deeper month/day/ time rungs and the equality terminal went untested. Add fixed both-ISO examples covering every rung above, below, and equal.