### PR TITLE
test: Cover AOT shape fast-path, resolver imports, and defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,8 +69,11 @@ jobs:
           # extra permissions come from paseri-vite-plugin/deno.json via -P. No --doc (not doc-tested)
           # and no --unstable-unsafe-proto (it doesn't exercise __proto__ Annex B semantics).
           deno test -P --parallel --coverage=.cov-vite-plugin paseri-vite-plugin/
+          # --exclude overrides Deno's default test-file exclusion, so restate it and add the generated-fixtures
+          # dir: those modules exist only to be type-checked, never executed, so they don't belong in the metric.
+          # (Executed generated code like regex.gen.ts and runtime.gen.ts is not under that dir and stays counted.)
           extract() {
-            deno coverage "$1" --include="$2" | grep "All files" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d '|' -f 3 | xargs
+            deno coverage "$1" --include="$2" --exclude='(test\.(js|mjs|ts|jsx|tsx)$|generated-fixtures/)' | grep "All files" | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | cut -d '|' -f 3 | xargs
           }
           echo "LIB_COVERAGE=$(extract .cov-lib paseri-lib/src/)" >> $GITHUB_OUTPUT
           echo "COMPILER_COVERAGE=$(extract .cov-compiler paseri-compiler/src/)" >> $GITHUB_OUTPUT

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -30,6 +30,7 @@
     "exclude": [
       "src/**/*.test.ts",
       "src/_test-helpers.ts",
+      "src/_import-fixtures.ts",
       "src/aot-shadow.ts",
       "src/runtime.ts",
       "src/generated-fixtures"

--- a/paseri-compiler/src/_import-fixtures.ts
+++ b/paseri-compiler/src/_import-fixtures.ts
@@ -1,0 +1,14 @@
+// Test fixture imported by resolver.test.ts. When a refine predicate references one of these, the compiler must
+// reproduce the user's import in the generated module — this exercises each import kind (default / named / aliased
+// / namespace) through the resolver's `formatImport`.
+
+function isPositive(value: number): boolean {
+    return value > 0;
+}
+
+function isNonEmpty(value: string): boolean {
+    return value.length > 0;
+}
+
+export default isPositive;
+export { isNonEmpty };

--- a/paseri-compiler/src/aot-shadow.ts
+++ b/paseri-compiler/src/aot-shadow.ts
@@ -14,8 +14,11 @@ import { toSource } from './toSource.ts';
 // these URLs synchronously. Add new entries here if a new test file imports from a URL the generated parity
 // validator will reproduce.
 const PASERI_LIB_INDEX_URL = new URL('../../paseri-lib/src/index.ts', import.meta.url).href;
+// Fixture that resolver.test.ts references from refine predicates, so its imports are reproduced in generated modules.
+const IMPORT_FIXTURES_URL = new URL('./_import-fixtures.ts', import.meta.url).href;
 const moduleCache = new Map<string, unknown>([
     [PASERI_LIB_INDEX_URL, await import(PASERI_LIB_INDEX_URL)],
+    [IMPORT_FIXTURES_URL, await import(IMPORT_FIXTURES_URL)],
     // Generated validators import the result/message contract from this subpath (keyed by the bare specifier the
     // generated `import` uses, which `bindImports` looks up verbatim).
     ['@paseri/paseri/internal', await import('@paseri/paseri/internal')],

--- a/paseri-compiler/src/resolver.test.ts
+++ b/paseri-compiler/src/resolver.test.ts
@@ -2,6 +2,8 @@ import * as p from '@paseri/paseri';
 import { expect } from '@std/expect';
 import { it } from '@std/testing/bdd';
 import './aot-shadow.ts';
+import * as helpers from './_import-fixtures.ts';
+import isPositive, { isNonEmpty as check, isNonEmpty } from './_import-fixtures.ts';
 
 // Helpers live at top level so the resolver finds them when it scans this file as the refine call site. Each exercises
 // a way the resolver can mis-resolve a callback's free identifiers and emit a validator that diverges from the runtime.
@@ -45,6 +47,64 @@ it('does not emit broken code when a captured identifier collides with a reserve
     const result = schema.safeParse(6);
     if (result.ok) {
         expect(result.value).toBe(6);
+    } else {
+        expect(result.ok).toBeTruthy();
+    }
+});
+
+it('resolves a predicate written as a named function rather than an arrow', () => {
+    const schema = p.number().refine(
+        function positivePredicate(value) {
+            return value > 0;
+        },
+        { code: 'positive' },
+    );
+    const result = schema.safeParse(5);
+    if (result.ok) {
+        expect(result.value).toBe(5);
+    } else {
+        expect(result.ok).toBeTruthy();
+    }
+});
+
+// When a predicate references an imported binding, the compiler reproduces the user's import in the generated
+// module. One test per import kind exercises the resolver's `formatImport` branches (parity checks the binding
+// actually resolves to the same helper at runtime and AOT).
+it('reproduces a default import referenced by a predicate', () => {
+    const schema = p.number().refine((value) => isPositive(value), { code: 'positive' });
+    const result = schema.safeParse(5);
+    if (result.ok) {
+        expect(result.value).toBe(5);
+    } else {
+        expect(result.ok).toBeTruthy();
+    }
+});
+
+it('reproduces a named import referenced by a predicate', () => {
+    const schema = p.string().refine((value) => isNonEmpty(value), { code: 'non_empty' });
+    const result = schema.safeParse('a');
+    if (result.ok) {
+        expect(result.value).toBe('a');
+    } else {
+        expect(result.ok).toBeTruthy();
+    }
+});
+
+it('reproduces an aliased named import referenced by a predicate', () => {
+    const schema = p.string().refine((value) => check(value), { code: 'non_empty' });
+    const result = schema.safeParse('a');
+    if (result.ok) {
+        expect(result.value).toBe('a');
+    } else {
+        expect(result.ok).toBeTruthy();
+    }
+});
+
+it('reproduces a namespace import referenced by a predicate', () => {
+    const schema = p.string().refine((value) => helpers.isNonEmpty(value), { code: 'non_empty' });
+    const result = schema.safeParse('a');
+    if (result.ok) {
+        expect(result.value).toBe('a');
     } else {
         expect(result.ok).toBeTruthy();
     }

--- a/paseri-lib/src/schemas/default.test.ts
+++ b/paseri-lib/src/schemas/default.test.ts
@@ -102,6 +102,35 @@ describe('collection defaults', () => {
             expect(result.ok).toBeTruthy();
         }
     });
+
+    // A default is cloned and frozen at construction, then handed back for undefined input, so it must round-trip
+    // for any value — exercise the range (negative/large bigints, boundary dates), not one hand-picked value.
+    // (Temporal instances can't be `.default()` values: `structuredClone` rejects them at construction.)
+    it('returns a bigint default verbatim for undefined input', () => {
+        fc.assert(
+            fc.property(fc.bigInt(), (value) => {
+                const result = p.bigint().optional().default(value).safeParse(undefined);
+                if (result.ok) {
+                    expect(result.value).toBe(value);
+                } else {
+                    expect(result.ok).toBeTruthy();
+                }
+            }),
+        );
+    });
+
+    it('returns a Date default verbatim for undefined input', () => {
+        fc.assert(
+            fc.property(fc.date({ noInvalidDate: true }), (value) => {
+                const result = p.date().optional().default(value).safeParse(undefined);
+                if (result.ok) {
+                    expect(result.value).toEqual(value);
+                } else {
+                    expect(result.ok).toBeTruthy();
+                }
+            }),
+        );
+    });
 });
 
 describe('object key defaults', () => {

--- a/paseri-lib/src/schemas/lazy.test.ts
+++ b/paseri-lib/src/schemas/lazy.test.ts
@@ -226,5 +226,10 @@ describe('maxDepth', () => {
         expect(() => schema.safeParse({ children: [] }, { maxDepth: Number.POSITIVE_INFINITY })).toThrow();
         expect(() => schema.safeParse({ children: [] }, { maxDepth: 0 })).toThrow();
         expect(() => schema.safeParse({ children: [] }, { maxDepth: 1 })).not.toThrow();
+
+        // `parse` validates maxDepth through the same guard as `safeParse`.
+        expect(() => schema.parse({ children: [] }, { maxDepth: Number.NaN })).toThrow();
+        expect(() => schema.parse({ children: [] }, { maxDepth: 0 })).toThrow();
+        expect(() => schema.parse({ children: [] }, { maxDepth: 1 })).not.toThrow();
     });
 });

--- a/paseri-lib/src/schemas/object.test.ts
+++ b/paseri-lib/src/schemas/object.test.ts
@@ -951,3 +951,161 @@ describe('required', () => {
         expect(required).not.toBe(original);
     });
 });
+
+// Wrapping a schema as an object field must validate identically to the bare schema: same acceptance, same
+// transformed output, and any issue path simply gains the field key as a prefix. Covers every field kind in a
+// nested position, driven generatively rather than with hand-picked inputs.
+function expectNestingInvariance<OutputType>(schema: p.Schema<OutputType>, arb: fc.Arbitrary<unknown>): void {
+    const nested = p.object({ inner: schema });
+    fc.assert(
+        fc.property(arb, (value) => {
+            const bare = schema.safeParse(value);
+            const wrapped = nested.safeParse({ inner: value });
+            expect(wrapped.ok).toBe(bare.ok);
+            if (bare.ok && wrapped.ok) {
+                expect(wrapped.value).toEqual({ inner: bare.value });
+            } else if (!bare.ok && !wrapped.ok) {
+                const expected = bare.messages().map((issue) => ({
+                    path: ['inner', ...issue.path],
+                    message: issue.message,
+                }));
+                expect(wrapped.messages()).toEqual(expected);
+            }
+        }),
+    );
+}
+
+describe('nested field validation', () => {
+    const cases: { name: string; check: () => void }[] = [
+        {
+            name: 'string with checks',
+            check: () =>
+                expectNestingInvariance(
+                    p.string().min(2).max(8).includes('a').startsWith('x').endsWith('z'),
+                    fc.oneof(fc.string(), fc.constant('xaz')),
+                ),
+        },
+        {
+            name: 'string format',
+            check: () => expectNestingInvariance(p.string().url(), fc.oneof(fc.webUrl(), fc.string())),
+        },
+        {
+            name: 'number with checks',
+            check: () => expectNestingInvariance(p.number().gte(0).lte(100).int(), fc.oneof(fc.integer(), fc.double())),
+        },
+        {
+            name: 'bigint with checks',
+            check: () => expectNestingInvariance(p.bigint().gte(0n).lte(100n), fc.bigInt()),
+        },
+        {
+            name: 'nullable',
+            check: () => expectNestingInvariance(p.number().nullable(), fc.oneof(fc.double(), fc.constant(null))),
+        },
+        {
+            name: 'optional',
+            check: () =>
+                expectNestingInvariance(p.string().min(1).optional(), fc.option(fc.string(), { nil: undefined })),
+        },
+        {
+            name: 'default',
+            check: () =>
+                expectNestingInvariance(p.number().optional().default(5), fc.option(fc.double(), { nil: undefined })),
+        },
+        {
+            name: 'refine',
+            check: () =>
+                expectNestingInvariance(
+                    p.number().refine((value) => value > 0, { code: 'not_positive' }),
+                    fc.double(),
+                ),
+        },
+        {
+            name: 'enum',
+            check: () =>
+                expectNestingInvariance(p.enum('a', 'b'), fc.oneof(fc.constantFrom<string>('a', 'b'), fc.string())),
+        },
+        {
+            name: 'array',
+            check: () => expectNestingInvariance(p.array(p.number()), fc.array(fc.oneof(fc.double(), fc.string()))),
+        },
+        {
+            name: 'record',
+            check: () =>
+                expectNestingInvariance(
+                    p.record(p.number()),
+                    fc.dictionary(fc.string(), fc.oneof(fc.double(), fc.string())),
+                ),
+        },
+        {
+            name: 'set',
+            check: () =>
+                expectNestingInvariance(
+                    p.set(p.number()),
+                    fc.array(fc.double()).map((values) => new Set(values)),
+                ),
+        },
+        {
+            name: 'map',
+            check: () =>
+                expectNestingInvariance(
+                    p.map(p.string(), p.number()),
+                    fc.array(fc.tuple(fc.string(), fc.double())).map((entries) => new Map(entries)),
+                ),
+        },
+        {
+            name: 'tuple',
+            check: () =>
+                expectNestingInvariance(
+                    p.tuple(p.number(), p.string()),
+                    fc.tuple(fc.oneof(fc.double(), fc.string()), fc.string()),
+                ),
+        },
+        {
+            name: 'union',
+            check: () =>
+                expectNestingInvariance(
+                    p.union(p.number(), p.string()),
+                    fc.oneof(fc.double(), fc.string(), fc.boolean()),
+                ),
+        },
+    ];
+    for (const { name, check } of cases) {
+        it(name, check);
+    }
+
+    // Temporal instances aren't fast-check-friendly, so exercise the nested temporal-type checks with fixed values.
+    it('temporal types', () => {
+        const schema = p.object({
+            inner: p.object({
+                date: p.date(),
+                duration: p.duration(),
+                instant: p.instant(),
+                plainDate: p.plainDate(),
+                plainDateTime: p.plainDateTime(),
+                plainMonthDay: p.plainMonthDay(),
+                plainTime: p.plainTime(),
+                plainYearMonth: p.plainYearMonth(),
+                zonedDateTime: p.zonedDateTime(),
+            }),
+        });
+        const inner = {
+            date: new Date('2020-01-01'),
+            duration: Temporal.Duration.from({ hours: 1 }),
+            instant: Temporal.Instant.from('2020-01-01T00:00:00Z'),
+            plainDate: Temporal.PlainDate.from('2020-01-01'),
+            plainDateTime: Temporal.PlainDateTime.from('2020-01-01T00:00:00'),
+            plainMonthDay: Temporal.PlainMonthDay.from('01-01'),
+            plainTime: Temporal.PlainTime.from('00:00:00'),
+            plainYearMonth: Temporal.PlainYearMonth.from('2020-01'),
+            zonedDateTime: Temporal.ZonedDateTime.from('2020-01-01T00:00:00[UTC]'),
+        };
+        expect(schema.safeParse({ inner }).ok).toBe(true);
+
+        const result = schema.safeParse({ inner: { ...inner, plainDate: 'not-a-date' } });
+        if (!result.ok) {
+            expect(result.messages()).toEqual([{ path: ['inner', 'plainDate'], message: 'invalid_type' }]);
+        } else {
+            expect(result.ok).toBeFalsy();
+        }
+    });
+});


### PR DESCRIPTION
A coverage sweep found meaningful validation and compiler paths with no tests:
- AOT shape fast-path for typed nested fields, via a nesting-invariance property checked by parity
- parse()'s maxDepth guard (only safeParse was exercised)
- resolver reproduction of default/named/aliased/namespace imports and named-function predicates
- bigint and Date default-value embedding