### PR TITLE
fix: Make the changeset gate follow the published file set

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -33,15 +33,13 @@ jobs:
           git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null
           git rev-parse --verify "$HEAD_SHA^{commit}" >/dev/null
 
-          # Watch each publishable member's src/ (the set `deno publish` ships),
-          # so a new package is gated without editing this workflow.
-          mapfile -t src_dirs < <(deno eval 'const { listPublishableMembers } = await import("./bin/lib/workspace.ts"); for (const m of await listPublishableMembers(new URL("file://" + Deno.cwd() + "/"))) console.log(m.dir + "/src");')
+          # Require a changeset only for changes that ship to consumers: files `deno publish` includes for
+          # their member, honouring each member's publish include/exclude. Tests, test-only helpers, and
+          # generated fixtures are publish-excluded, so touching only those needs no changeset.
+          published_changes=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | deno run --allow-read bin/published-changes.ts)
 
-          src_changes=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- "${src_dirs[@]}" \
-            | grep -v '\.test\.ts$' || true)
-
-          if [ -z "$src_changes" ]; then
-            echo "No publishable src changes — changeset not required."
+          if [ -z "$published_changes" ]; then
+            echo "No published changes — changeset not required."
             exit 0
           fi
 
@@ -56,10 +54,10 @@ jobs:
           fi
 
           {
-            echo "::error::This PR modifies a publishable package's src/** but adds no changeset."
+            echo "::error::This PR changes files that ship to consumers but adds no changeset."
             echo "Run 'deno task changeset' locally, commit the generated .changeset/*.md, and push."
             echo ""
-            echo "Touched src files:"
-            echo "$src_changes" | sed 's/^/  /'
+            echo "Touched published files:"
+            echo "$published_changes" | sed 's/^/  /'
           } >&2
           exit 1

--- a/bin/lib/__fixtures__/publish-rules/bare/deno.json
+++ b/bin/lib/__fixtures__/publish-rules/bare/deno.json
@@ -1,0 +1,5 @@
+{
+  "name": "@scope/bare",
+  "version": "1.0.0",
+  "exports": "./src/index.ts"
+}

--- a/bin/lib/__fixtures__/publish-rules/deno.json
+++ b/bin/lib/__fixtures__/publish-rules/deno.json
@@ -1,0 +1,3 @@
+{
+  "workspace": ["pkg", "bare"]
+}

--- a/bin/lib/__fixtures__/publish-rules/pkg/deno.json
+++ b/bin/lib/__fixtures__/publish-rules/pkg/deno.json
@@ -1,0 +1,9 @@
+{
+  "name": "@scope/pkg",
+  "version": "1.0.0",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": ["src", "README.md"],
+    "exclude": ["src/**/*.test.ts", "src/_helper.ts", "src/generated"]
+  }
+}

--- a/bin/lib/workspace.test.ts
+++ b/bin/lib/workspace.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@std/expect';
 import { describe, it } from '@std/testing/bdd';
-import { listPublishableMembers } from './workspace.ts';
+import { listPublishableMembers, publishedChanges } from './workspace.ts';
 
 const fixtures = new URL('__fixtures__/', import.meta.url);
 
@@ -25,5 +25,37 @@ describe('listPublishableMembers', () => {
         await expect(listPublishableMembers(new URL('partial-config/', fixtures))).rejects.toThrow(
             /partially JSR-configured/,
         );
+    });
+});
+
+describe('publishedChanges', () => {
+    const root = new URL('publish-rules/', fixtures);
+
+    it('keeps files deno publish ships (in include, not excluded)', async () => {
+        expect(await publishedChanges(root, ['pkg/src/index.ts', 'pkg/README.md'])).toEqual([
+            'pkg/src/index.ts',
+            'pkg/README.md',
+        ]);
+    });
+
+    it('drops publish-excluded files: tests, named helpers, and generated directories', async () => {
+        expect(
+            await publishedChanges(root, ['pkg/src/index.test.ts', 'pkg/src/_helper.ts', 'pkg/src/generated/thing.ts']),
+        ).toEqual([]);
+    });
+
+    it('drops files outside the publish include set', async () => {
+        expect(await publishedChanges(root, ['pkg/deno.json', 'pkg/LICENSE.md'])).toEqual([]);
+    });
+
+    it('ignores paths not under any publishable member', async () => {
+        expect(await publishedChanges(root, ['.github/workflows/ci.yml', 'unrelated/file.ts'])).toEqual([]);
+    });
+
+    it('ships everything not excluded when a member declares no publish include', async () => {
+        expect(await publishedChanges(root, ['bare/src/index.ts', 'bare/anything.ts'])).toEqual([
+            'bare/src/index.ts',
+            'bare/anything.ts',
+        ]);
     });
 });

--- a/bin/lib/workspace.ts
+++ b/bin/lib/workspace.ts
@@ -1,3 +1,5 @@
+import { globToRegExp } from 'jsr:@std/path@^1.1.5';
+
 // Enumerates the JSR-publishable members of the Deno workspace. A member
 // is considered publishable iff its deno.json declares all of name,
 // version, and exports — the same set of fields JSR requires, so this
@@ -69,5 +71,49 @@ async function readLatestChangelogEntry(member: PublishableMember): Promise<stri
     return (end === -1 ? rest : rest.slice(0, end)).join('\n').trim();
 }
 
+// A publish include/exclude entry is a glob, a single file, or a directory (matching everything under it) —
+// the three shapes `deno publish` accepts.
+function matchesPublishEntry(relativePath: string, entry: string): boolean {
+    if (/[*?[\]{}]/.test(entry)) {
+        return globToRegExp(entry, { globstar: true, extended: true }).test(relativePath);
+    }
+    return relativePath === entry || relativePath.startsWith(`${entry}/`);
+}
+
+// Filters repo-relative changed paths down to those `deno publish` actually ships, applying each member's
+// publish include/exclude. Test files, test-only helpers, and generated fixtures are publish-excluded, so a
+// change touching only those ships nothing and needs no changeset.
+async function publishedChanges(rootUrl: URL, paths: readonly string[]): Promise<string[]> {
+    const members = await listPublishableMembers(rootUrl);
+    const rules = new Map<string, { include: string[]; exclude: string[] }>();
+    for (const member of members) {
+        const { publish } = await readJson<{ publish?: { include?: string[]; exclude?: string[] } }>(
+            member.denoJsonUrl,
+        );
+        rules.set(member.dir, { include: publish?.include ?? [], exclude: publish?.exclude ?? [] });
+    }
+
+    const published: string[] = [];
+    for (const path of paths) {
+        const member = members.find((candidate) => path === candidate.dir || path.startsWith(`${candidate.dir}/`));
+        if (member === undefined) {
+            continue;
+        }
+        const rule = rules.get(member.dir);
+        if (rule === undefined) {
+            continue;
+        }
+        const relativePath = path.slice(member.dir.length + 1);
+        // An empty include means `deno publish` ships everything not excluded.
+        const included =
+            rule.include.length === 0 || rule.include.some((entry) => matchesPublishEntry(relativePath, entry));
+        const excluded = rule.exclude.some((entry) => matchesPublishEntry(relativePath, entry));
+        if (included && !excluded) {
+            published.push(path);
+        }
+    }
+    return published;
+}
+
 export type { PublishableMember };
-export { listPublishableMembers, readJson, readLatestChangelogEntry };
+export { listPublishableMembers, publishedChanges, readJson, readLatestChangelogEntry };

--- a/bin/published-changes.ts
+++ b/bin/published-changes.ts
@@ -1,0 +1,15 @@
+// CLI wrapper for the changeset gate: reads repo-relative changed paths (one per line on stdin) and prints
+// the ones `deno publish` ships, via publishedChanges. Non-empty output means the PR needs a changeset.
+
+import { publishedChanges } from './lib/workspace.ts';
+
+const rootUrl = new URL('../', import.meta.url);
+const input = await new Response(Deno.stdin.readable).text();
+const paths = input
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+for (const path of await publishedChanges(rootUrl, paths)) {
+    console.log(path);
+}


### PR DESCRIPTION
It required a changeset for any src change except *.test.ts, so it fired on publish-excluded test infrastructure (aot-shadow, _import-fixtures, generated fixtures). Now derive each member's shipped set from its publish include/exclude, so only consumer-facing changes are gated.