### PR TITLE
Release: @paseri/paseri@1.9.4, @paseri/compiler@0.7.4, @paseri/vite-plugin@0.2.1

### DIFF
--- a/.changeset/default-clone-freeze-reject.md
+++ b/.changeset/default-clone-freeze-reject.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-`.default()` now handles more value kinds correctly. A Temporal instance nested inside a mutable default (e.g. `p.object({ when: p.plainDate() }).optional().default({ when })`) previously threw `DataCloneError` at construction; it now works. Top-level Temporal defaults are frozen, so a property added to one parsed result can't leak into later parses. Function and symbol defaults are now rejected at construction: a default must be a value Paseri can clone and reproduce, which a function or symbol isn't.

--- a/.changeset/frozen-map-set-defaults-immutable.md
+++ b/.changeset/frozen-map-set-defaults-immutable.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-`Map` and `Set` `.default()` values are now truly immutable. Previously `Object.freeze` left their `set`/`add`/`delete`/`clear` methods working, so the shared default could be mutated and the change leaked into every later parse. Those mutators now throw, matching frozen plain objects.

--- a/.changeset/guard-extensionless-schema.md
+++ b/.changeset/guard-extensionless-schema.md
@@ -1,5 +1,0 @@
----
-"@paseri/vite-plugin": patch
----
-
-The plugin's usage guard now recognises schema imports written without the `.ts` extension (e.g. `import { User } from './user.schema'`), not just `./user.schema.ts`. A derivation call on such an import (e.g. `User.optional()`) is now flagged at build time instead of slipping through to a runtime failure.

--- a/.changeset/object-derivation-through-wrappers.md
+++ b/.changeset/object-derivation-through-wrappers.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`.required()` and `.partial()` now see through the `nullable` and `refine` wrappers. Previously `.required()` silently no-op'd on `.optional().nullable()` / `.optional().refine()` fields (a missing key was still accepted); it now strips the optional layer while keeping the field nullable/refined, matching TypeScript's `Required`. `.partial()` now keeps the default fill on a wrapped default (e.g. `.optional().default(v).refine(...)`) instead of dropping it, and the field's inferred type no longer offers a `.default()` that throws when called.

--- a/.changeset/object-pick-omit-preserve-mode.md
+++ b/.changeset/object-pick-omit-preserve-mode.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`.pick()` and `.omit()` now preserve the object's mode. Previously they reverted to `strict`, so `.strip().pick(...)` rejected extra keys and `.passthrough().omit(...)` dropped them.

--- a/.changeset/record-string-keys.md
+++ b/.changeset/record-string-keys.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-`p.record()` now infers `Record<string, Element>` instead of `Record<PropertyKey, Element>`. The old type claimed symbol-keyed values were `Element`, but the runtime never validates symbol keys — they pass through untouched, the same way object schemas treat them. The narrowed type matches that string-keyed behaviour; numeric-literal access (`result[1]`) still works and `keyof` is still `string | number`.

--- a/.changeset/resolver-fresh-reproducible.md
+++ b/.changeset/resolver-fresh-reproducible.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A refine/chain callback that references a `const` with a non-fixed value (e.g. `Date.now()`) is no longer compiled into a validator holding a one-off snapshot of it — the compiler can't reproduce such a value, so it leaves the schema uncompiled rather than bake in one that differs from the runtime. Separately, a source file is re-read after it changes on disk, so a watch/dev rebuild reflects edits to a referenced helper instead of reusing a stale parse.

--- a/.changeset/standard-schema-inferinput.md
+++ b/.changeset/standard-schema-inferinput.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Fixed the Standard Schema input type. `StandardSchemaV1.InferInput` on a Paseri schema previously reported the output type instead of `unknown` — backwards for transforming schemas (a `string`→`number` chain inferred its input as `number`). It now infers `unknown` input (matching `safeParse`), with `InferOutput` the parsed type.

--- a/.changeset/url-numeric-host.md
+++ b/.changeset/url-numeric-host.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().url()` now rejects URLs whose host is an invalid all-numeric address — e.g. `http://999999999999`, `http://1.2.3.4.5`, `http://256.0` — which it previously accepted. These are malformed IPv4 per the WHATWG URL standard; genuine IPv4 like `http://1.2.3.4` is still accepted.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @paseri/compiler
 
+## 0.7.4
+
+### Patch Changes
+
+- c98af4b: `.default()` now handles more value kinds correctly. A Temporal instance nested inside a mutable default (e.g. `p.object({ when: p.plainDate() }).optional().default({ when })`) previously threw `DataCloneError` at construction; it now works. Top-level Temporal defaults are frozen, so a property added to one parsed result can't leak into later parses. Function and symbol defaults are now rejected at construction: a default must be a value Paseri can clone and reproduce, which a function or symbol isn't.
+- 3a7e0a9: `Map` and `Set` `.default()` values are now truly immutable. Previously `Object.freeze` left their `set`/`add`/`delete`/`clear` methods working, so the shared default could be mutated and the change leaked into every later parse. Those mutators now throw, matching frozen plain objects.
+- 9ece7bd: `p.record()` now infers `Record<string, Element>` instead of `Record<PropertyKey, Element>`. The old type claimed symbol-keyed values were `Element`, but the runtime never validates symbol keys — they pass through untouched, the same way object schemas treat them. The narrowed type matches that string-keyed behaviour; numeric-literal access (`result[1]`) still works and `keyof` is still `string | number`.
+- 1087972: A refine/chain callback that references a `const` with a non-fixed value (e.g. `Date.now()`) is no longer compiled into a validator holding a one-off snapshot of it — the compiler can't reproduce such a value, so it leaves the schema uncompiled rather than bake in one that differs from the runtime. Separately, a source file is re-read after it changes on disk, so a watch/dev rebuild reflects edits to a referenced helper instead of reusing a stale parse.
+
 ## 0.7.3
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @paseri/paseri
 
+## 1.9.4
+
+### Patch Changes
+
+- c98af4b: `.default()` now handles more value kinds correctly. A Temporal instance nested inside a mutable default (e.g. `p.object({ when: p.plainDate() }).optional().default({ when })`) previously threw `DataCloneError` at construction; it now works. Top-level Temporal defaults are frozen, so a property added to one parsed result can't leak into later parses. Function and symbol defaults are now rejected at construction: a default must be a value Paseri can clone and reproduce, which a function or symbol isn't.
+- 3a7e0a9: `Map` and `Set` `.default()` values are now truly immutable. Previously `Object.freeze` left their `set`/`add`/`delete`/`clear` methods working, so the shared default could be mutated and the change leaked into every later parse. Those mutators now throw, matching frozen plain objects.
+- 02b5e72: `.required()` and `.partial()` now see through the `nullable` and `refine` wrappers. Previously `.required()` silently no-op'd on `.optional().nullable()` / `.optional().refine()` fields (a missing key was still accepted); it now strips the optional layer while keeping the field nullable/refined, matching TypeScript's `Required`. `.partial()` now keeps the default fill on a wrapped default (e.g. `.optional().default(v).refine(...)`) instead of dropping it, and the field's inferred type no longer offers a `.default()` that throws when called.
+- 3493f74: `.pick()` and `.omit()` now preserve the object's mode. Previously they reverted to `strict`, so `.strip().pick(...)` rejected extra keys and `.passthrough().omit(...)` dropped them.
+- 9ece7bd: `p.record()` now infers `Record<string, Element>` instead of `Record<PropertyKey, Element>`. The old type claimed symbol-keyed values were `Element`, but the runtime never validates symbol keys — they pass through untouched, the same way object schemas treat them. The narrowed type matches that string-keyed behaviour; numeric-literal access (`result[1]`) still works and `keyof` is still `string | number`.
+- b6af635: Fixed the Standard Schema input type. `StandardSchemaV1.InferInput` on a Paseri schema previously reported the output type instead of `unknown` — backwards for transforming schemas (a `string`→`number` chain inferred its input as `number`). It now infers `unknown` input (matching `safeParse`), with `InferOutput` the parsed type.
+- b463299: `p.string().url()` now rejects URLs whose host is an invalid all-numeric address — e.g. `http://999999999999`, `http://1.2.3.4.5`, `http://256.0` — which it previously accepted. These are malformed IPv4 per the WHATWG URL standard; genuine IPv4 like `http://1.2.3.4` is still accepted.
+
 ## 1.9.3
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",

--- a/paseri-vite-plugin/CHANGELOG.md
+++ b/paseri-vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/vite-plugin
 
+## 0.2.1
+
+### Patch Changes
+
+- bec6f8e: The plugin's usage guard now recognises schema imports written without the `.ts` extension (e.g. `import { User } from './user.schema'`), not just `./user.schema.ts`. A derivation call on such an import (e.g. `User.optional()`) is now flagged at build time instead of slipping through to a runtime failure.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/paseri-vite-plugin/deno.json
+++ b/paseri-vite-plugin/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/vite-plugin",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Vite plugin that AOT-compiles Paseri schemas at build time.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## @paseri/paseri 1.9.4

### Patch Changes

- c98af4b: `.default()` now handles more value kinds correctly. A Temporal instance nested inside a mutable default (e.g. `p.object({ when: p.plainDate() }).optional().default({ when })`) previously threw `DataCloneError` at construction; it now works. Top-level Temporal defaults are frozen, so a property added to one parsed result can't leak into later parses. Function and symbol defaults are now rejected at construction: a default must be a value Paseri can clone and reproduce, which a function or symbol isn't.
- 3a7e0a9: `Map` and `Set` `.default()` values are now truly immutable. Previously `Object.freeze` left their `set`/`add`/`delete`/`clear` methods working, so the shared default could be mutated and the change leaked into every later parse. Those mutators now throw, matching frozen plain objects.
- 02b5e72: `.required()` and `.partial()` now see through the `nullable` and `refine` wrappers. Previously `.required()` silently no-op'd on `.optional().nullable()` / `.optional().refine()` fields (a missing key was still accepted); it now strips the optional layer while keeping the field nullable/refined, matching TypeScript's `Required`. `.partial()` now keeps the default fill on a wrapped default (e.g. `.optional().default(v).refine(...)`) instead of dropping it, and the field's inferred type no longer offers a `.default()` that throws when called.
- 3493f74: `.pick()` and `.omit()` now preserve the object's mode. Previously they reverted to `strict`, so `.strip().pick(...)` rejected extra keys and `.passthrough().omit(...)` dropped them.
- 9ece7bd: `p.record()` now infers `Record<string, Element>` instead of `Record<PropertyKey, Element>`. The old type claimed symbol-keyed values were `Element`, but the runtime never validates symbol keys — they pass through untouched, the same way object schemas treat them. The narrowed type matches that string-keyed behaviour; numeric-literal access (`result[1]`) still works and `keyof` is still `string | number`.
- b6af635: Fixed the Standard Schema input type. `StandardSchemaV1.InferInput` on a Paseri schema previously reported the output type instead of `unknown` — backwards for transforming schemas (a `string`→`number` chain inferred its input as `number`). It now infers `unknown` input (matching `safeParse`), with `InferOutput` the parsed type.
- b463299: `p.string().url()` now rejects URLs whose host is an invalid all-numeric address — e.g. `http://999999999999`, `http://1.2.3.4.5`, `http://256.0` — which it previously accepted. These are malformed IPv4 per the WHATWG URL standard; genuine IPv4 like `http://1.2.3.4` is still accepted.

## @paseri/compiler 0.7.4

### Patch Changes

- c98af4b: `.default()` now handles more value kinds correctly. A Temporal instance nested inside a mutable default (e.g. `p.object({ when: p.plainDate() }).optional().default({ when })`) previously threw `DataCloneError` at construction; it now works. Top-level Temporal defaults are frozen, so a property added to one parsed result can't leak into later parses. Function and symbol defaults are now rejected at construction: a default must be a value Paseri can clone and reproduce, which a function or symbol isn't.
- 3a7e0a9: `Map` and `Set` `.default()` values are now truly immutable. Previously `Object.freeze` left their `set`/`add`/`delete`/`clear` methods working, so the shared default could be mutated and the change leaked into every later parse. Those mutators now throw, matching frozen plain objects.
- 9ece7bd: `p.record()` now infers `Record<string, Element>` instead of `Record<PropertyKey, Element>`. The old type claimed symbol-keyed values were `Element`, but the runtime never validates symbol keys — they pass through untouched, the same way object schemas treat them. The narrowed type matches that string-keyed behaviour; numeric-literal access (`result[1]`) still works and `keyof` is still `string | number`.
- 1087972: A refine/chain callback that references a `const` with a non-fixed value (e.g. `Date.now()`) is no longer compiled into a validator holding a one-off snapshot of it — the compiler can't reproduce such a value, so it leaves the schema uncompiled rather than bake in one that differs from the runtime. Separately, a source file is re-read after it changes on disk, so a watch/dev rebuild reflects edits to a referenced helper instead of reusing a stale parse.

## @paseri/vite-plugin 0.2.1

### Patch Changes

- bec6f8e: The plugin's usage guard now recognises schema imports written without the `.ts` extension (e.g. `import { User } from './user.schema'`), not just `./user.schema.ts`. A derivation call on such an import (e.g. `User.optional()`) is now flagged at build time instead of slipping through to a runtime failure.