### PR TITLE
fix: Sync deno.lock with the bumped dependency ranges

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -6,40 +6,40 @@
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@^1.4.0": "1.4.0",
     "jsr:@std/data-structures@^1.1.0": "1.1.0",
-    "jsr:@std/expect@^1.0.19": "1.0.19",
+    "jsr:@std/expect@^1.0.19": "1.0.20",
+    "jsr:@std/expect@^1.0.20": "1.0.20",
     "jsr:@std/fs@^1.0.24": "1.0.24",
     "jsr:@std/internal@^1.0.12": "1.0.14",
-    "jsr:@std/internal@^1.0.13": "1.0.14",
     "jsr:@std/internal@^1.0.14": "1.0.14",
-    "jsr:@std/path@^1.1.4": "1.1.5",
-    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/path@^1.1.5": "1.1.6",
+    "jsr:@std/path@^1.1.6": "1.1.6",
     "jsr:@std/testing@^1.0.19": "1.0.19",
     "jsr:@vbudovski/rollup-plugin-transform-regex@~0.1.4": "0.1.4",
     "npm:@astrojs/check@~0.9.9": "0.9.9_typescript@6.0.3",
-    "npm:@astrojs/preact@6": "6.0.0_preact@10.29.2_@types+node@26.0.1",
+    "npm:@astrojs/preact@6": "6.0.0_preact@10.29.3",
     "npm:@astrojs/sitemap@^3.7.3": "3.7.3",
-    "npm:@astrojs/starlight@0.41": "0.41.1_astro@7.0.3__@astrojs+markdown-remark@7.2.0__@types+node@26.0.1_@types+node@26.0.1",
+    "npm:@astrojs/starlight@~0.41.1": "0.41.2_astro@7.0.4__@astrojs+markdown-remark@7.2.0_typescript@6.0.3",
     "npm:@biomejs/biome@^2.5.1": "2.5.2",
     "npm:@changesets/cli@^2.31.0": "2.31.0_@types+node@26.0.1",
     "npm:@commitlint/cli@^21.1.0": "21.2.0_@types+node@26.0.1_typescript@6.0.3",
     "npm:@commitlint/config-conventional@^21.1.0": "21.2.0",
     "npm:@commitlint/types@^21.1.0": "21.2.0",
     "npm:@preact/signals-core@^1.14.3": "1.14.3",
-    "npm:@preact/signals@^2.9.2": "2.9.2_preact@10.29.2",
+    "npm:@preact/signals@^2.9.2": "2.9.2_preact@10.29.3",
     "npm:@rollup/pluginutils@^5.3.0": "5.3.0_rollup@4.62.2",
     "npm:@sveltejs/acorn-typescript@^1.0.10": "1.0.10_acorn@8.17.0",
     "npm:@types/estree@^1.0.8": "1.0.9",
     "npm:acorn@^8.17.0": "8.17.0",
-    "npm:astro@^7.0.3": "7.0.3_@astrojs+markdown-remark@7.2.0_@types+node@26.0.1",
+    "npm:astro@^7.0.4": "7.0.4_@astrojs+markdown-remark@7.2.0",
     "npm:charts.css@^1.2.0": "1.2.0",
     "npm:codejar@^4.3.0": "4.3.0",
     "npm:estree-walker@^3.0.3": "3.0.3",
-    "npm:expect-type@^1.3.0": "1.3.0",
+    "npm:expect-type@^1.4.0": "1.4.0",
     "npm:fast-check@^4.8.0": "4.8.0",
     "npm:husky@^9.1.7": "9.1.7",
     "npm:lint-staged@^17.0.8": "17.0.8",
     "npm:magic-string@~0.30.21": "0.30.21",
-    "npm:preact@^10.29.2": "10.29.2",
+    "npm:preact@^10.29.3": "10.29.3",
     "npm:recheck@^4.5.0": "4.5.0",
     "npm:regex@^6.1.0": "6.1.0",
     "npm:regexp-tree@~0.1.27": "0.1.27",
@@ -74,12 +74,12 @@
     "@std/data-structures@1.1.0": {
       "integrity": "c35ae4ad5d8e41a38573c2fe3e19b18ea2505f63cfea201edcb8720aca1f7f58"
     },
-    "@std/expect@1.0.19": {
-      "integrity": "25271785688c7ff902fa54875d6aa4001f552c5578f7f0fefb5b5aac1fc2ed8a",
+    "@std/expect@1.0.20": {
+      "integrity": "ffc4f3c33f732417e3e9acf3d995818c89984313c37d933b9ebbb4571d2887e9",
       "dependencies": [
         "jsr:@std/assert",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.6"
       ]
     },
     "@std/fs@1.0.24": {
@@ -93,6 +93,12 @@
     },
     "@std/path@1.1.5": {
       "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
       "dependencies": [
         "jsr:@std/internal@^1.0.14"
       ]
@@ -133,55 +139,55 @@
       ],
       "bin": true
     },
-    "@astrojs/compiler-binding-darwin-arm64@0.2.3": {
-      "integrity": "sha512-sJIHeL1ONXEBLob8ZaXfmX6iCftUno08G/cMXj2FJnL0xNbHuELcEq1mjxHVFHNgUYu4P7xJNm2mpc0zUEPoKw==",
+    "@astrojs/compiler-binding-darwin-arm64@0.3.0": {
+      "integrity": "sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@astrojs/compiler-binding-darwin-x64@0.2.3": {
-      "integrity": "sha512-P0NYu6aaIeLCqFfszxxBHL0a5WRaYigNVbDoO654Gi5Q2au5duDb5xZBv5EqUg4qnQVC173FXNvGZu1M7nk+/w==",
+    "@astrojs/compiler-binding-darwin-x64@0.3.0": {
+      "integrity": "sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@astrojs/compiler-binding-linux-arm64-gnu@0.2.3": {
-      "integrity": "sha512-PqVN5AqhuDqfx3ejaerwrC8codpV9jnyKV+IOel027qsJ1anFUJLdjUlY8VVys0xgd8lmqveX11OkcaQj/otTg==",
+    "@astrojs/compiler-binding-linux-arm64-gnu@0.3.0": {
+      "integrity": "sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@astrojs/compiler-binding-linux-arm64-musl@0.2.3": {
-      "integrity": "sha512-O3e2CbN4yTsRguWYNnRd0p5YQ0H3fb7KpcR0W4R319q/gq5B1pJ7eqNbiO3b8g2AuiEcRTiUz5jeGT9j69cxOQ==",
+    "@astrojs/compiler-binding-linux-arm64-musl@0.3.0": {
+      "integrity": "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@astrojs/compiler-binding-linux-x64-gnu@0.2.3": {
-      "integrity": "sha512-hbLBjXVp+96psMe7/7uqyrquGiULXANrq6REVxxPK/I5VzebZ7LHmSfykmByUbLyR1u+K6CTBKgvdQsK2L+2Xw==",
+    "@astrojs/compiler-binding-linux-x64-gnu@0.3.0": {
+      "integrity": "sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@astrojs/compiler-binding-linux-x64-musl@0.2.3": {
-      "integrity": "sha512-vIiEvOwrJfHZMaTmqUCrFTIwMYL0+PD3Rvy7kFDQgERyx3zhaw8CPa01MCCqa+/sj344BGrXKZ6ti37SgNLMhw==",
+    "@astrojs/compiler-binding-linux-x64-musl@0.3.0": {
+      "integrity": "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@astrojs/compiler-binding-wasm32-wasi@0.2.3": {
-      "integrity": "sha512-p9S2X8z/mUR2SMzAVJRFMCt8YaalKR+pjl2DgpdjzCQc6ww4bo8kiy54tgKqxZeNF5c+/2tCDTQIxVSm9V1FsA==",
+    "@astrojs/compiler-binding-wasm32-wasi@0.3.0": {
+      "integrity": "sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==",
       "dependencies": [
         "@napi-rs/wasm-runtime"
       ],
       "cpu": ["wasm32"]
     },
-    "@astrojs/compiler-binding-win32-arm64-msvc@0.2.3": {
-      "integrity": "sha512-vcCG6JttIb5vbSmcxO2O398hpVj7lQ349iS7cjgYP6ZuLVEnw+9qPAr2MM2kJkU5wEGZqJ2gyi/M7UJoPwH1iQ==",
+    "@astrojs/compiler-binding-win32-arm64-msvc@0.3.0": {
+      "integrity": "sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@astrojs/compiler-binding-win32-x64-msvc@0.2.3": {
-      "integrity": "sha512-hKssjNvC36e00Inb1GW1JsVyCFSCGnIjKem4S8q0VIW6cpWAUpvYB4qQU2HIDGD6SDX0ork4F5sWkNWkp2hrGQ==",
+    "@astrojs/compiler-binding-win32-x64-msvc@0.3.0": {
+      "integrity": "sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@astrojs/compiler-binding@0.2.3": {
-      "integrity": "sha512-Xz3iBNse+hXXD25IXxsuXEt2ai8klAWE15CRm/EQBc9+aE3jXaF07DZx+iakk3HC6NHvWlEPzLPyxsLgPzOJsw==",
+    "@astrojs/compiler-binding@0.3.0": {
+      "integrity": "sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A==",
       "optionalDependencies": [
         "@astrojs/compiler-binding-darwin-arm64",
         "@astrojs/compiler-binding-darwin-x64",
@@ -194,8 +200,8 @@
         "@astrojs/compiler-binding-win32-x64-msvc"
       ]
     },
-    "@astrojs/compiler-rs@0.2.3": {
-      "integrity": "sha512-JRAtRcPxS4JeAZEIQFQ6GecBs/Wyp4m6/E8vBNxSgVfo1AtRVLUqRCl5oCGOZ0X/BSBB3Vef/7IlzyiGKi2ORA==",
+    "@astrojs/compiler-rs@0.3.0": {
+      "integrity": "sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==",
       "dependencies": [
         "@astrojs/compiler-binding"
       ]
@@ -271,7 +277,7 @@
         "satteri"
       ]
     },
-    "@astrojs/mdx@7.0.0_@astrojs+markdown-satteri@0.3.2_astro@7.0.3__@astrojs+markdown-remark@7.2.0__@types+node@26.0.1_@types+node@26.0.1": {
+    "@astrojs/mdx@7.0.0_@astrojs+markdown-satteri@0.3.2_astro@7.0.4__@astrojs+markdown-remark@7.2.0": {
       "integrity": "sha512-LKwNA8nnLtEM0auoP6OfH/UnlKe1Ub59qZjbcYkZjPBGw6PkJewWkA/1qwLpECvV6gMDd6TR6eqV9p/VYZrcrQ==",
       "dependencies": [
         "@astrojs/internal-helpers",
@@ -295,7 +301,7 @@
         "@astrojs/markdown-satteri"
       ]
     },
-    "@astrojs/preact@6.0.0_preact@10.29.2_@types+node@26.0.1": {
+    "@astrojs/preact@6.0.0_preact@10.29.3": {
       "integrity": "sha512-8FYeEsn0GGld1aoSsZlKtroZfk7/fWcSJNDsI3QSslgngyhUKvDbC9XYsgwlsTBn1egEgeniDQ3uh7L/aqmiGw==",
       "dependencies": [
         "@astrojs/internal-helpers",
@@ -321,8 +327,8 @@
         "zod"
       ]
     },
-    "@astrojs/starlight@0.41.1_astro@7.0.3__@astrojs+markdown-remark@7.2.0__@types+node@26.0.1_@types+node@26.0.1": {
-      "integrity": "sha512-avf2OmrVg6GdVU18juebjjIIuLa+uS3syHuJ/3yDaEFP/8it+YvcxRrYDSf7K6rC4v770UxIddba2hAqQyTeYA==",
+    "@astrojs/starlight@0.41.2_astro@7.0.4__@astrojs+markdown-remark@7.2.0_typescript@6.0.3": {
+      "integrity": "sha512-1h9AhFW5uWgqEoTqOVLMnXvawa0TaqLSr14UyTbnArQL6W0TolTfMWpG5hrvbw+NO6wwdSOFz5iwhVtkGUBtsw==",
       "dependencies": [
         "@astrojs/markdown-satteri",
         "@astrojs/mdx",
@@ -1322,34 +1328,18 @@
     "@img/colour@1.1.0": {
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="
     },
-    "@img/sharp-darwin-arm64@0.34.5": {
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-darwin-arm64@1.2.4"
-      ],
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
     "@img/sharp-darwin-arm64@0.35.2": {
       "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
       "optionalDependencies": [
-        "@img/sharp-libvips-darwin-arm64@1.3.1"
+        "@img/sharp-libvips-darwin-arm64"
       ],
       "os": ["darwin"],
       "cpu": ["arm64"]
-    },
-    "@img/sharp-darwin-x64@0.34.5": {
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-darwin-x64@1.2.4"
-      ],
-      "os": ["darwin"],
-      "cpu": ["x64"]
     },
     "@img/sharp-darwin-x64@0.35.2": {
       "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
       "optionalDependencies": [
-        "@img/sharp-libvips-darwin-x64@1.3.1"
+        "@img/sharp-libvips-darwin-x64"
       ],
       "os": ["darwin"],
       "cpu": ["x64"]
@@ -1357,244 +1347,123 @@
     "@img/sharp-freebsd-wasm32@0.35.2": {
       "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
       "dependencies": [
-        "@img/sharp-wasm32@0.35.2"
+        "@img/sharp-wasm32"
       ],
       "os": ["freebsd"]
-    },
-    "@img/sharp-libvips-darwin-arm64@1.2.4": {
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-darwin-arm64@1.3.1": {
       "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-darwin-x64@1.2.4": {
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
     "@img/sharp-libvips-darwin-x64@1.3.1": {
       "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
-    },
-    "@img/sharp-libvips-linux-arm64@1.2.4": {
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-linux-arm64@1.3.1": {
       "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-linux-arm@1.2.4": {
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
     "@img/sharp-libvips-linux-arm@1.3.1": {
       "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
       "os": ["linux"],
       "cpu": ["arm"]
-    },
-    "@img/sharp-libvips-linux-ppc64@1.2.4": {
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "os": ["linux"],
-      "cpu": ["ppc64"]
     },
     "@img/sharp-libvips-linux-ppc64@1.3.1": {
       "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
-    "@img/sharp-libvips-linux-riscv64@1.2.4": {
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "os": ["linux"],
-      "cpu": ["riscv64"]
-    },
     "@img/sharp-libvips-linux-riscv64@1.3.1": {
       "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
       "os": ["linux"],
       "cpu": ["riscv64"]
-    },
-    "@img/sharp-libvips-linux-s390x@1.2.4": {
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "os": ["linux"],
-      "cpu": ["s390x"]
     },
     "@img/sharp-libvips-linux-s390x@1.3.1": {
       "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
-    "@img/sharp-libvips-linux-x64@1.2.4": {
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
     "@img/sharp-libvips-linux-x64@1.3.1": {
       "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
       "os": ["linux"],
       "cpu": ["x64"]
-    },
-    "@img/sharp-libvips-linuxmusl-arm64@1.2.4": {
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
     },
     "@img/sharp-libvips-linuxmusl-arm64@1.3.1": {
       "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-libvips-linuxmusl-x64@1.2.4": {
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
     "@img/sharp-libvips-linuxmusl-x64@1.3.1": {
       "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@img/sharp-linux-arm64@0.34.5": {
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
     "@img/sharp-linux-arm64@0.35.2": {
       "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm64@1.3.1"
+        "@img/sharp-libvips-linux-arm64"
       ],
       "os": ["linux"],
       "cpu": ["arm64"]
-    },
-    "@img/sharp-linux-arm@0.34.5": {
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["arm"]
     },
     "@img/sharp-linux-arm@0.35.2": {
       "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-arm@1.3.1"
+        "@img/sharp-libvips-linux-arm"
       ],
       "os": ["linux"],
       "cpu": ["arm"]
     },
-    "@img/sharp-linux-ppc64@0.34.5": {
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-ppc64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["ppc64"]
-    },
     "@img/sharp-linux-ppc64@0.35.2": {
       "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-ppc64@1.3.1"
+        "@img/sharp-libvips-linux-ppc64"
       ],
       "os": ["linux"],
       "cpu": ["ppc64"]
-    },
-    "@img/sharp-linux-riscv64@0.34.5": {
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-riscv64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["riscv64"]
     },
     "@img/sharp-linux-riscv64@0.35.2": {
       "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-riscv64@1.3.1"
+        "@img/sharp-libvips-linux-riscv64"
       ],
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@img/sharp-linux-s390x@0.34.5": {
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-s390x@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["s390x"]
-    },
     "@img/sharp-linux-s390x@0.35.2": {
       "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-s390x@1.3.1"
+        "@img/sharp-libvips-linux-s390x"
       ],
       "os": ["linux"],
       "cpu": ["s390x"]
-    },
-    "@img/sharp-linux-x64@0.34.5": {
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linux-x64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["x64"]
     },
     "@img/sharp-linux-x64@0.35.2": {
       "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linux-x64@1.3.1"
+        "@img/sharp-libvips-linux-x64"
       ],
       "os": ["linux"],
       "cpu": ["x64"]
-    },
-    "@img/sharp-linuxmusl-arm64@0.34.5": {
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-arm64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["arm64"]
     },
     "@img/sharp-linuxmusl-arm64@0.35.2": {
       "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-arm64@1.3.1"
+        "@img/sharp-libvips-linuxmusl-arm64"
       ],
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-linuxmusl-x64@0.34.5": {
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-x64@1.2.4"
-      ],
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
     "@img/sharp-linuxmusl-x64@0.35.2": {
       "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
       "optionalDependencies": [
-        "@img/sharp-libvips-linuxmusl-x64@1.3.1"
+        "@img/sharp-libvips-linuxmusl-x64"
       ],
       "os": ["linux"],
       "cpu": ["x64"]
-    },
-    "@img/sharp-wasm32@0.34.5": {
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "dependencies": [
-        "@emnapi/runtime"
-      ],
-      "cpu": ["wasm32"]
     },
     "@img/sharp-wasm32@0.35.2": {
       "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
@@ -1605,34 +1474,19 @@
     "@img/sharp-webcontainers-wasm32@0.35.2": {
       "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
       "dependencies": [
-        "@img/sharp-wasm32@0.35.2"
+        "@img/sharp-wasm32"
       ],
       "cpu": ["wasm32"]
-    },
-    "@img/sharp-win32-arm64@0.34.5": {
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
     },
     "@img/sharp-win32-arm64@0.35.2": {
       "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@img/sharp-win32-ia32@0.34.5": {
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "os": ["win32"],
-      "cpu": ["ia32"]
-    },
     "@img/sharp-win32-ia32@0.35.2": {
       "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
       "os": ["win32"],
       "cpu": ["ia32"]
-    },
-    "@img/sharp-win32-x64@0.34.5": {
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "os": ["win32"],
-      "cpu": ["x64"]
     },
     "@img/sharp-win32-x64@0.35.2": {
       "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
@@ -1799,7 +1653,7 @@
     "@pkgr/core@0.1.2": {
       "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ=="
     },
-    "@preact/preset-vite@2.10.5_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1_@types+node@26.0.1": {
+    "@preact/preset-vite@2.10.5_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1_preact@10.29.3": {
       "integrity": "sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==",
       "dependencies": [
         "@babel/core",
@@ -1819,7 +1673,7 @@
     "@preact/signals-core@1.14.3": {
       "integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw=="
     },
-    "@preact/signals@2.9.2_preact@10.29.2": {
+    "@preact/signals@2.9.2_preact@10.29.3": {
       "integrity": "sha512-DvFPISNMSh3vPqRwPa1tAVAHl85aDq4pTyNu1bTGfrKr64F3EOCHjdUl9aUdohKBf1v9PRGLYuGFcJpfztkdoQ==",
       "dependencies": [
         "@preact/signals-core",
@@ -1829,7 +1683,7 @@
     "@prefresh/babel-plugin@0.5.3": {
       "integrity": "sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ=="
     },
-    "@prefresh/core@1.5.10_preact@10.29.2": {
+    "@prefresh/core@1.5.10_preact@10.29.3": {
       "integrity": "sha512-7yPTFbG56sutaFu8krp3B4a200KOFUvrtlllKWRuLjsYXo9UUucHOZRcer+gtgMkFTpv6ob8TGcTwA32bSwa1w==",
       "dependencies": [
         "preact"
@@ -1838,7 +1692,7 @@
     "@prefresh/utils@1.2.1": {
       "integrity": "sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw=="
     },
-    "@prefresh/vite@2.4.12_preact@10.29.2_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1_@types+node@26.0.1": {
+    "@prefresh/vite@2.4.12_preact@10.29.3_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1": {
       "integrity": "sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==",
       "dependencies": [
         "@babel/core",
@@ -2383,7 +2237,7 @@
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
       "bin": true
     },
-    "astro-expressive-code@0.44.0_astro@7.0.3__@astrojs+markdown-remark@7.2.0__@types+node@26.0.1_@types+node@26.0.1": {
+    "astro-expressive-code@0.44.0_astro@7.0.4__@astrojs+markdown-remark@7.2.0": {
       "integrity": "sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw==",
       "dependencies": [
         "astro",
@@ -2391,8 +2245,8 @@
         "url-extras"
       ]
     },
-    "astro@7.0.3_@astrojs+markdown-remark@7.2.0_@types+node@26.0.1": {
-      "integrity": "sha512-CK+G+Tl2DMV1EXCwVG45vyurxf2IfRTklMxDhRKn+tst9Yl8rWXpudL62Fa6zin5Bt968FBvuyASj1aJShROZg==",
+    "astro@7.0.4_@astrojs+markdown-remark@7.2.0": {
+      "integrity": "sha512-6DSiJ4CT69vngNlwEKec7nGOJHcPzc95lX7E6qkUhAt6drGYzUdf0KTJToswu3vFp3lTCGnNDCzBi/5aW8tTPA==",
       "dependencies": [
         "@astrojs/compiler-rs",
         "@astrojs/internal-helpers",
@@ -2430,7 +2284,7 @@
         "obug",
         "p-limit@7.3.0",
         "p-queue",
-        "package-manager-detector@1.6.0",
+        "package-manager-detector@1.7.0",
         "piccolore",
         "picomatch@4.0.4",
         "rehype",
@@ -2453,7 +2307,7 @@
         "zod"
       ],
       "optionalDependencies": [
-        "sharp@0.34.5"
+        "sharp"
       ],
       "optionalPeers": [
         "@astrojs/markdown-remark"
@@ -3005,8 +2859,8 @@
     "eventemitter3@5.0.4": {
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
-    "expect-type@1.3.0": {
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="
+    "expect-type@1.4.0": {
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="
     },
     "expressive-code@0.44.0": {
       "integrity": "sha512-JXVWVNCKlLuZLMQH8cOiDUSosT0Bb+elwE/dbAkpwFwDFmyFyWlECoWZIohh2FkIF1iI67TQJ+Ts9k7oNDh2qA==",
@@ -3440,8 +3294,8 @@
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "bin": true
     },
-    "i18next@26.3.3_typescript@6.0.3": {
-      "integrity": "sha512-aYVegyBdXSO93CMMihvr47jI7GHSOcIahMpJX+qzUXDzW4xDJf2uenIA+45vDU+YhiVdcfsql70AC9RVdMNrHg==",
+    "i18next@26.3.4_typescript@6.0.3": {
+      "integrity": "sha512-pa7m0d7pBDqGHZxljT+WPFeyFgQ7P7SciPPo1tTqYuO0z4sqADYhwnBESmmGp/wEof1inwdls/k8ZgTg8rxFHA==",
       "dependencies": [
         "typescript"
       ],
@@ -4467,8 +4321,8 @@
         "quansync"
       ]
     },
-    "package-manager-detector@1.6.0": {
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="
+    "package-manager-detector@1.7.0": {
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="
     },
     "pagefind@1.5.2": {
       "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
@@ -4579,14 +4433,14 @@
     "powershell-utils@0.1.0": {
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="
     },
-    "preact-render-to-string@6.7.0_preact@10.29.2": {
+    "preact-render-to-string@6.7.0_preact@10.29.3": {
       "integrity": "sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==",
       "dependencies": [
         "preact"
       ]
     },
-    "preact@10.29.2": {
-      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="
+    "preact@10.29.3": {
+      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw=="
     },
     "prettier@2.8.8": {
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
@@ -5036,41 +4890,6 @@
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "bin": true
     },
-    "sharp@0.34.5": {
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dependencies": [
-        "@img/colour",
-        "detect-libc",
-        "semver@7.8.5"
-      ],
-      "optionalDependencies": [
-        "@img/sharp-darwin-arm64@0.34.5",
-        "@img/sharp-darwin-x64@0.34.5",
-        "@img/sharp-libvips-darwin-arm64@1.2.4",
-        "@img/sharp-libvips-darwin-x64@1.2.4",
-        "@img/sharp-libvips-linux-arm@1.2.4",
-        "@img/sharp-libvips-linux-arm64@1.2.4",
-        "@img/sharp-libvips-linux-ppc64@1.2.4",
-        "@img/sharp-libvips-linux-riscv64@1.2.4",
-        "@img/sharp-libvips-linux-s390x@1.2.4",
-        "@img/sharp-libvips-linux-x64@1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64@1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64@1.2.4",
-        "@img/sharp-linux-arm@0.34.5",
-        "@img/sharp-linux-arm64@0.34.5",
-        "@img/sharp-linux-ppc64@0.34.5",
-        "@img/sharp-linux-riscv64@0.34.5",
-        "@img/sharp-linux-s390x@0.34.5",
-        "@img/sharp-linux-x64@0.34.5",
-        "@img/sharp-linuxmusl-arm64@0.34.5",
-        "@img/sharp-linuxmusl-x64@0.34.5",
-        "@img/sharp-wasm32@0.34.5",
-        "@img/sharp-win32-arm64@0.34.5",
-        "@img/sharp-win32-ia32@0.34.5",
-        "@img/sharp-win32-x64@0.34.5"
-      ],
-      "scripts": true
-    },
     "sharp@0.35.2": {
       "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
       "dependencies": [
@@ -5079,31 +4898,31 @@
         "semver@7.8.5"
       ],
       "optionalDependencies": [
-        "@img/sharp-darwin-arm64@0.35.2",
-        "@img/sharp-darwin-x64@0.35.2",
+        "@img/sharp-darwin-arm64",
+        "@img/sharp-darwin-x64",
         "@img/sharp-freebsd-wasm32",
-        "@img/sharp-libvips-darwin-arm64@1.3.1",
-        "@img/sharp-libvips-darwin-x64@1.3.1",
-        "@img/sharp-libvips-linux-arm@1.3.1",
-        "@img/sharp-libvips-linux-arm64@1.3.1",
-        "@img/sharp-libvips-linux-ppc64@1.3.1",
-        "@img/sharp-libvips-linux-riscv64@1.3.1",
-        "@img/sharp-libvips-linux-s390x@1.3.1",
-        "@img/sharp-libvips-linux-x64@1.3.1",
-        "@img/sharp-libvips-linuxmusl-arm64@1.3.1",
-        "@img/sharp-libvips-linuxmusl-x64@1.3.1",
-        "@img/sharp-linux-arm@0.35.2",
-        "@img/sharp-linux-arm64@0.35.2",
-        "@img/sharp-linux-ppc64@0.35.2",
-        "@img/sharp-linux-riscv64@0.35.2",
-        "@img/sharp-linux-s390x@0.35.2",
-        "@img/sharp-linux-x64@0.35.2",
-        "@img/sharp-linuxmusl-arm64@0.35.2",
-        "@img/sharp-linuxmusl-x64@0.35.2",
+        "@img/sharp-libvips-darwin-arm64",
+        "@img/sharp-libvips-darwin-x64",
+        "@img/sharp-libvips-linux-arm",
+        "@img/sharp-libvips-linux-arm64",
+        "@img/sharp-libvips-linux-ppc64",
+        "@img/sharp-libvips-linux-riscv64",
+        "@img/sharp-libvips-linux-s390x",
+        "@img/sharp-libvips-linux-x64",
+        "@img/sharp-libvips-linuxmusl-arm64",
+        "@img/sharp-libvips-linuxmusl-x64",
+        "@img/sharp-linux-arm",
+        "@img/sharp-linux-arm64",
+        "@img/sharp-linux-ppc64",
+        "@img/sharp-linux-riscv64",
+        "@img/sharp-linux-s390x",
+        "@img/sharp-linux-x64",
+        "@img/sharp-linuxmusl-arm64",
+        "@img/sharp-linuxmusl-x64",
         "@img/sharp-webcontainers-wasm32",
-        "@img/sharp-win32-arm64@0.35.2",
-        "@img/sharp-win32-ia32@0.35.2",
-        "@img/sharp-win32-x64@0.35.2"
+        "@img/sharp-win32-arm64",
+        "@img/sharp-win32-ia32",
+        "@img/sharp-win32-x64"
       ]
     },
     "shebang-command@2.0.0": {
@@ -5544,7 +5363,7 @@
       ],
       "bin": true
     },
-    "vitefu@1.1.3_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1_@types+node@26.0.1": {
+    "vitefu@1.1.3_vite@8.1.2__@types+node@26.0.1__esbuild@0.28.1": {
       "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "dependencies": [
         "vite@8.1.2_@types+node@26.0.1_esbuild@0.28.1"
@@ -5828,9 +5647,9 @@
     "members": {
       "paseri-compiler": {
         "dependencies": [
-          "jsr:@std/expect@^1.0.19",
+          "jsr:@std/expect@^1.0.20",
           "jsr:@std/testing@^1.0.19",
-          "npm:expect-type@^1.3.0",
+          "npm:expect-type@^1.4.0",
           "npm:ts-blank-space@0.9",
           "npm:typescript@^6.0.3",
           "npm:zod@^4.4.3"
@@ -5841,13 +5660,13 @@
           "npm:@astrojs/check@~0.9.9",
           "npm:@astrojs/preact@6",
           "npm:@astrojs/sitemap@^3.7.3",
-          "npm:@astrojs/starlight@0.41",
+          "npm:@astrojs/starlight@~0.41.1",
           "npm:@preact/signals-core@^1.14.3",
           "npm:@preact/signals@^2.9.2",
-          "npm:astro@^7.0.3",
+          "npm:astro@^7.0.4",
           "npm:charts.css@^1.2.0",
           "npm:codejar@^4.3.0",
-          "npm:preact@^10.29.2",
+          "npm:preact@^10.29.3",
           "npm:rehype-external-links@3",
           "npm:rollup-plugin-visualizer@^7.0.1",
           "npm:sharp@~0.35.2",
@@ -5860,13 +5679,13 @@
         "dependencies": [
           "jsr:@badrap/valita@~0.5.4",
           "jsr:@standard-schema/spec@^1.1.0",
-          "jsr:@std/expect@^1.0.19",
-          "jsr:@std/path@^1.1.5",
+          "jsr:@std/expect@^1.0.20",
+          "jsr:@std/path@^1.1.6",
           "jsr:@std/testing@^1.0.19",
           "jsr:@vbudovski/rollup-plugin-transform-regex@~0.1.4",
           "npm:@sveltejs/acorn-typescript@^1.0.10",
           "npm:acorn@^8.17.0",
-          "npm:expect-type@^1.3.0",
+          "npm:expect-type@^1.4.0",
           "npm:fast-check@^4.8.0",
           "npm:recheck@^4.5.0",
           "npm:regex@^6.1.0",


### PR DESCRIPTION
Dependabot commit 9047909 bumped the deno.json ranges without regenerating the lockfile, so the committed lock was stale. Regenerated via `deno install`; `deno install --frozen` passes.