### PR TITLE
Release: @paseri/paseri@1.9.5, @paseri/compiler@0.7.5, @paseri/vite-plugin@0.2.2

### DIFF
--- a/.changeset/aot-default-nested-extras-perf.md
+++ b/.changeset/aot-default-nested-extras-perf.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A compiled object that combines a `.default()` field with a nested `.strict()` or `.strip()` object now compiles to a faster validator.

--- a/.changeset/aot-default-object-gate.md
+++ b/.changeset/aot-default-object-gate.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A compiled object schema with a `.default()` field now rejects a plain-looking object whose own `constructor` is `undefined`. Previously it was accepted.

--- a/.changeset/aot-import-specifier-escaping.md
+++ b/.changeset/aot-import-specifier-escaping.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiling a schema whose refine/chain callback imports from a path containing an apostrophe (e.g. `/Users/o'brien/schema.ts`) no longer emits a module with a `SyntaxError`.

--- a/.changeset/aot-negative-zero-default.md
+++ b/.changeset/aot-negative-zero-default.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A compiled object schema with both a `-0` default and a `0` default now keeps them distinct, instead of emitting `-0` for both.

--- a/.changeset/aot-proto-wrapped-default.md
+++ b/.changeset/aot-proto-wrapped-default.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A compiled object schema with a field named `__proto__` (or `constructor`, etc.) carrying a wrapped default now fires that default when the field is absent, instead of failing with `invalid_type` in browsers/Node.js.

--- a/.changeset/aot-sparse-array-default.md
+++ b/.changeset/aot-sparse-array-default.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiling a schema with a sparse-array default (e.g. `[1, , 3]`) no longer crashes the compiler with an opaque `TypeError`.

--- a/.changeset/email-domain-hyphen.md
+++ b/.changeset/email-domain-hyphen.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().email()` now rejects an address whose domain label ends with a hyphen (e.g. `foo@a-.com`), matching the hostname-label rule that a label may not begin or end with `-`. Interior hyphens (`foo@a-b.com`) remain valid.

--- a/.changeset/emoji-rgi.md
+++ b/.changeset/emoji-rgi.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().emoji()` now rejects bare emoji component code points — digits, `#`, `*`, and lone regional indicators — that previously validated as emoji. Per Unicode, these are emoji only inside a sequence, so keycaps (`1️⃣`), flags (`🇦🇺`), and other emoji sequences are still accepted.

--- a/.changeset/object-inherited-key-mask.md
+++ b/.changeset/object-inherited-key-mask.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-An object schema now rejects an invalid value in a non-enumerable own property when the input also carries an inherited enumerable key; that combination previously let the invalid value pass unvalidated. Only objects built with `Object.create` / `Object.defineProperty` can trigger it — JSON, object literals, and spreads are unaffected.

--- a/.changeset/object-numeric-key-derivation.md
+++ b/.changeset/object-numeric-key-derivation.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`.pick()`, `.omit()`, `.partial()`, and `.required()` now work on objects with numeric keys (e.g. `p.object({ 1: p.string() })`). Previously `.pick(1)` threw `Object must contain at least one field.` and `.omit(1)` / `.partial(1)` / `.required(1)` silently did nothing.

--- a/.changeset/object-strip-nested-strict-extras.md
+++ b/.changeset/object-strip-nested-strict-extras.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-A compiled `.strip()` object with a `.default()` field now handles unknown keys inside a nested `.strict()` or `.strip()` object correctly, matching the runtime: rejected for `.strict()`, dropped for `.strip()`. Previously the generated validator let them through.

--- a/.changeset/object-strip-nonenumerable.md
+++ b/.changeset/object-strip-nonenumerable.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-A `.strip()` object schema now keeps a validated non-enumerable own property in its output instead of dropping it while removing unrecognised keys. Only reachable for objects built with `Object.create` / `Object.defineProperty`; JSON, object literals, and spreads are unaffected.

--- a/.changeset/offset-hour-range.md
+++ b/.changeset/offset-hour-range.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().time({ offset: true })` and `p.string().datetime({ offset: true })` now reject a timezone offset whose hour is above 23 (e.g. `12:34:56+45:00`). The offset hour is validated as 00-23, matching the time-of-day hour.

--- a/.changeset/reject-non-serialisable-defaults.md
+++ b/.changeset/reject-non-serialisable-defaults.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-`.default()` now throws `A default value cannot be a <type>.` at construction when given a value it can't faithfully store — a RegExp, typed array, Error, or other class instance (at any depth). Previously such a value was silently corrupted.

--- a/.changeset/union-discriminator-refine.md
+++ b/.changeset/union-discriminator-refine.md
@@ -1,6 +1,0 @@
----
-"@paseri/paseri": patch
-"@paseri/compiler": patch
----
-
-When a member of a discriminated union is wrapped in `.refine()`, an unknown discriminator value now reports a single `invalid_discriminator_value` — matching a union with no refined members — instead of aggregated per-member issues. The refined member's own checks still run once its tag is matched.

--- a/.changeset/vite-aggregator-string-export-name.md
+++ b/.changeset/vite-aggregator-string-export-name.md
@@ -1,5 +1,0 @@
----
-"@paseri/vite-plugin": patch
----
-
-A `.schema.ts` file that exports a schema under a string name (e.g. `export { schema as "my-schema" }`) no longer breaks the build with a `SyntaxError`.

--- a/.changeset/vite-default-export-schema.md
+++ b/.changeset/vite-default-export-schema.md
@@ -1,5 +1,0 @@
----
-"@paseri/vite-plugin": patch
----
-
-A `.schema.ts` that exports its schema as the module default (`export default p.object(…)`) now compiles, instead of failing the build with "no Paseri schema exports".

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @paseri/compiler
 
+## 0.7.5
+
+### Patch Changes
+
+- 4fd9e0f: A compiled object that combines a `.default()` field with a nested `.strict()` or `.strip()` object now compiles to a faster validator.
+- 20ee684: A compiled object schema with a `.default()` field now rejects a plain-looking object whose own `constructor` is `undefined`. Previously it was accepted.
+- c6f42d5: Compiling a schema whose refine/chain callback imports from a path containing an apostrophe (e.g. `/Users/o'brien/schema.ts`) no longer emits a module with a `SyntaxError`.
+- 73e1388: A compiled object schema with both a `-0` default and a `0` default now keeps them distinct, instead of emitting `-0` for both.
+- 42fc1ad: A compiled object schema with a field named `__proto__` (or `constructor`, etc.) carrying a wrapped default now fires that default when the field is absent, instead of failing with `invalid_type` in browsers/Node.js.
+- 37cd88c: Compiling a schema with a sparse-array default (e.g. `[1, , 3]`) no longer crashes the compiler with an opaque `TypeError`.
+- f522046: A compiled `.strip()` object with a `.default()` field now handles unknown keys inside a nested `.strict()` or `.strip()` object correctly, matching the runtime: rejected for `.strict()`, dropped for `.strip()`. Previously the generated validator let them through.
+- 1b3e5a0: `.default()` now throws `A default value cannot be a <type>.` at construction when given a value it can't faithfully store — a RegExp, typed array, Error, or other class instance (at any depth). Previously such a value was silently corrupted.
+- 8ca9780: When a member of a discriminated union is wrapped in `.refine()`, an unknown discriminator value now reports a single `invalid_discriminator_value` — matching a union with no refined members — instead of aggregated per-member issues. The refined member's own checks still run once its tag is matched.
+
 ## 0.7.4
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @paseri/paseri
 
+## 1.9.5
+
+### Patch Changes
+
+- d998a86: `p.string().email()` now rejects an address whose domain label ends with a hyphen (e.g. `foo@a-.com`), matching the hostname-label rule that a label may not begin or end with `-`. Interior hyphens (`foo@a-b.com`) remain valid.
+- b354c8f: `p.string().emoji()` now rejects bare emoji component code points — digits, `#`, `*`, and lone regional indicators — that previously validated as emoji. Per Unicode, these are emoji only inside a sequence, so keycaps (`1️⃣`), flags (`🇦🇺`), and other emoji sequences are still accepted.
+- 74fe3f0: An object schema now rejects an invalid value in a non-enumerable own property when the input also carries an inherited enumerable key; that combination previously let the invalid value pass unvalidated. Only objects built with `Object.create` / `Object.defineProperty` can trigger it — JSON, object literals, and spreads are unaffected.
+- 78c453c: `.pick()`, `.omit()`, `.partial()`, and `.required()` now work on objects with numeric keys (e.g. `p.object({ 1: p.string() })`). Previously `.pick(1)` threw `Object must contain at least one field.` and `.omit(1)` / `.partial(1)` / `.required(1)` silently did nothing.
+- 17549aa: A `.strip()` object schema now keeps a validated non-enumerable own property in its output instead of dropping it while removing unrecognised keys. Only reachable for objects built with `Object.create` / `Object.defineProperty`; JSON, object literals, and spreads are unaffected.
+- f850d39: `p.string().time({ offset: true })` and `p.string().datetime({ offset: true })` now reject a timezone offset whose hour is above 23 (e.g. `12:34:56+45:00`). The offset hour is validated as 00-23, matching the time-of-day hour.
+- 1b3e5a0: `.default()` now throws `A default value cannot be a <type>.` at construction when given a value it can't faithfully store — a RegExp, typed array, Error, or other class instance (at any depth). Previously such a value was silently corrupted.
+- 8ca9780: When a member of a discriminated union is wrapped in `.refine()`, an unknown discriminator value now reports a single `invalid_discriminator_value` — matching a union with no refined members — instead of aggregated per-member issues. The refined member's own checks still run once its tag is matched.
+
 ## 1.9.4
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",

--- a/paseri-vite-plugin/CHANGELOG.md
+++ b/paseri-vite-plugin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @paseri/vite-plugin
 
+## 0.2.2
+
+### Patch Changes
+
+- 3963cbb: A `.schema.ts` file that exports a schema under a string name (e.g. `export { schema as "my-schema" }`) no longer breaks the build with a `SyntaxError`.
+- e32d00a: A `.schema.ts` that exports its schema as the module default (`export default p.object(…)`) now compiles, instead of failing the build with "no Paseri schema exports".
+
 ## 0.2.1
 
 ### Patch Changes

--- a/paseri-vite-plugin/deno.json
+++ b/paseri-vite-plugin/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/vite-plugin",
   "license": "MIT",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Vite plugin that AOT-compiles Paseri schemas at build time.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## @paseri/paseri 1.9.5

### Patch Changes

- d998a86: `p.string().email()` now rejects an address whose domain label ends with a hyphen (e.g. `foo@a-.com`), matching the hostname-label rule that a label may not begin or end with `-`. Interior hyphens (`foo@a-b.com`) remain valid.
- b354c8f: `p.string().emoji()` now rejects bare emoji component code points — digits, `#`, `*`, and lone regional indicators — that previously validated as emoji. Per Unicode, these are emoji only inside a sequence, so keycaps (`1️⃣`), flags (`🇦🇺`), and other emoji sequences are still accepted.
- 74fe3f0: An object schema now rejects an invalid value in a non-enumerable own property when the input also carries an inherited enumerable key; that combination previously let the invalid value pass unvalidated. Only objects built with `Object.create` / `Object.defineProperty` can trigger it — JSON, object literals, and spreads are unaffected.
- 78c453c: `.pick()`, `.omit()`, `.partial()`, and `.required()` now work on objects with numeric keys (e.g. `p.object({ 1: p.string() })`). Previously `.pick(1)` threw `Object must contain at least one field.` and `.omit(1)` / `.partial(1)` / `.required(1)` silently did nothing.
- 17549aa: A `.strip()` object schema now keeps a validated non-enumerable own property in its output instead of dropping it while removing unrecognised keys. Only reachable for objects built with `Object.create` / `Object.defineProperty`; JSON, object literals, and spreads are unaffected.
- f850d39: `p.string().time({ offset: true })` and `p.string().datetime({ offset: true })` now reject a timezone offset whose hour is above 23 (e.g. `12:34:56+45:00`). The offset hour is validated as 00-23, matching the time-of-day hour.
- 1b3e5a0: `.default()` now throws `A default value cannot be a <type>.` at construction when given a value it can't faithfully store — a RegExp, typed array, Error, or other class instance (at any depth). Previously such a value was silently corrupted.
- 8ca9780: When a member of a discriminated union is wrapped in `.refine()`, an unknown discriminator value now reports a single `invalid_discriminator_value` — matching a union with no refined members — instead of aggregated per-member issues. The refined member's own checks still run once its tag is matched.

## @paseri/compiler 0.7.5

### Patch Changes

- 4fd9e0f: A compiled object that combines a `.default()` field with a nested `.strict()` or `.strip()` object now compiles to a faster validator.
- 20ee684: A compiled object schema with a `.default()` field now rejects a plain-looking object whose own `constructor` is `undefined`. Previously it was accepted.
- c6f42d5: Compiling a schema whose refine/chain callback imports from a path containing an apostrophe (e.g. `/Users/o'brien/schema.ts`) no longer emits a module with a `SyntaxError`.
- 73e1388: A compiled object schema with both a `-0` default and a `0` default now keeps them distinct, instead of emitting `-0` for both.
- 42fc1ad: A compiled object schema with a field named `__proto__` (or `constructor`, etc.) carrying a wrapped default now fires that default when the field is absent, instead of failing with `invalid_type` in browsers/Node.js.
- 37cd88c: Compiling a schema with a sparse-array default (e.g. `[1, , 3]`) no longer crashes the compiler with an opaque `TypeError`.
- f522046: A compiled `.strip()` object with a `.default()` field now handles unknown keys inside a nested `.strict()` or `.strip()` object correctly, matching the runtime: rejected for `.strict()`, dropped for `.strip()`. Previously the generated validator let them through.
- 1b3e5a0: `.default()` now throws `A default value cannot be a <type>.` at construction when given a value it can't faithfully store — a RegExp, typed array, Error, or other class instance (at any depth). Previously such a value was silently corrupted.
- 8ca9780: When a member of a discriminated union is wrapped in `.refine()`, an unknown discriminator value now reports a single `invalid_discriminator_value` — matching a union with no refined members — instead of aggregated per-member issues. The refined member's own checks still run once its tag is matched.

## @paseri/vite-plugin 0.2.2

### Patch Changes

- 3963cbb: A `.schema.ts` file that exports a schema under a string name (e.g. `export { schema as "my-schema" }`) no longer breaks the build with a `SyntaxError`.
- e32d00a: A `.schema.ts` that exports its schema as the module default (`export default p.object(…)`) now compiles, instead of failing the build with "no Paseri schema exports".