### PR TITLE
fix: Add a CI check that deno.lock matches the manifests

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 
@@ -96,7 +96,7 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_SIZE: ${{ steps.delta.outputs.pr_size }}
           MAIN_SIZE: ${{ steps.delta.outputs.main_size }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -1,0 +1,29 @@
+name: Lockfile check
+
+on: workflow_call
+
+permissions: {}
+
+jobs:
+  lockfile:
+    name: Lockfile check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: "^2.9.0"
+
+      - name: Verify deno.lock matches the manifests
+        run: |
+          # Dependabot bumps a member's deno.json range without regenerating the root workspace lock,
+          # so the committed deno.lock silently goes stale. --frozen errors when the lock can't satisfy
+          # the manifests (the drift), while staying quiet for a within-range upstream release the lock
+          # still satisfies. --lockfile-only checks without installing packages.
+          deno install --frozen --lockfile-only

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,11 @@ jobs:
       contents: read
     uses: ./.github/workflows/changeset-check.yml
 
+  lockfile:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/lockfile-check.yml
+
   zizmor:
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: "^2.9.0"
 
@@ -188,7 +188,7 @@ jobs:
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           LIB_PR: ${{ steps.delta.outputs.lib_pr }}
           LIB_MAIN: ${{ steps.delta.outputs.lib_main }}


### PR DESCRIPTION
Dependabot bumps a member's deno.json range without regenerating the root workspace lockfile, so a stale deno.lock can merge unnoticed (as in 9047909). A new pull-request job fails when the lock can't satisfy the manifests (`deno install --frozen --lockfile-only`), while staying quiet for a within-range upstream release the lock still satisfies.