### PR TITLE
Release: @paseri/paseri@1.9.6, @paseri/compiler@0.7.6, @paseri/vite-plugin@0.2.3

### DIFF
--- a/.changeset/compiler-irgraph-alias.md
+++ b/.changeset/compiler-irgraph-alias.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-The generated API documentation no longer shows `IRGraph` as an unresolved type on `toSource`.

--- a/.changeset/merge-cast-typefest-5-8.md
+++ b/.changeset/merge-cast-typefest-5-8.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Fixed a type error in the object schema's `merge()` implementation.

--- a/.changeset/public-api-jsdoc.md
+++ b/.changeset/public-api-jsdoc.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-The public schema methods (`parse`, `safeParse`, `optional`, `nullable`, `chain`, `refine`, `~standard`) and the introspection types are now documented, and internal-only symbols no longer appear in the generated API documentation.

--- a/.changeset/vite-plugin-plugin-alias.md
+++ b/.changeset/vite-plugin-plugin-alias.md
@@ -1,5 +1,0 @@
----
-"@paseri/vite-plugin": patch
----
-
-The generated API documentation no longer shows Vite's `Plugin` as an unresolved type on the `paseri` plugin.

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.7.6
+
+### Patch Changes
+
+- c854627: The generated API documentation no longer shows `IRGraph` as an unresolved type on `toSource`.
+
 ## 0.7.5
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @paseri/paseri
 
+## 1.9.6
+
+### Patch Changes
+
+- 65174b9: Fixed a type error in the object schema's `merge()` implementation.
+- 6f81d71: The public schema methods (`parse`, `safeParse`, `optional`, `nullable`, `chain`, `refine`, `~standard`) and the introspection types are now documented, and internal-only symbols no longer appear in the generated API documentation.
+
 ## 1.9.5
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",

--- a/paseri-vite-plugin/CHANGELOG.md
+++ b/paseri-vite-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/vite-plugin
 
+## 0.2.3
+
+### Patch Changes
+
+- c854627: The generated API documentation no longer shows Vite's `Plugin` as an unresolved type on the `paseri` plugin.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/paseri-vite-plugin/deno.json
+++ b/paseri-vite-plugin/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/vite-plugin",
   "license": "MIT",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Vite plugin that AOT-compiles Paseri schemas at build time.",
   "exports": {
     ".": "./src/index.ts"


### PR DESCRIPTION
## @paseri/paseri 1.9.6

### Patch Changes

- 65174b9: Fixed a type error in the object schema's `merge()` implementation.
- 6f81d71: The public schema methods (`parse`, `safeParse`, `optional`, `nullable`, `chain`, `refine`, `~standard`) and the introspection types are now documented, and internal-only symbols no longer appear in the generated API documentation.

## @paseri/compiler 0.7.6

### Patch Changes

- c854627: The generated API documentation no longer shows `IRGraph` as an unresolved type on `toSource`.

## @paseri/vite-plugin 0.2.3

### Patch Changes

- c854627: The generated API documentation no longer shows Vite's `Plugin` as an unresolved type on the `paseri` plugin.