### PR TITLE
Release: @paseri/paseri@1.9.7, @paseri/compiler@0.7.7

### DIFF
--- a/.changeset/compiler-standard-schema-direct.md
+++ b/.changeset/compiler-standard-schema-direct.md
@@ -1,5 +1,0 @@
----
-"@paseri/compiler": patch
----
-
-Compiled modules validate invalid inputs ~7-10% faster through the Standard Schema interface.

--- a/.changeset/ipv6-zone-id-case-folding.md
+++ b/.changeset/ipv6-zone-id-case-folding.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`p.string().ip()` and `p.string().cidr()` now reject IPv6 zone IDs containing U+212A (Kelvin sign) or U+017F (long s), e.g. `fe80::1%ſ1`; zone IDs are ASCII-only per RFC 6874.

--- a/.changeset/regex-case-folding.md
+++ b/.changeset/regex-case-folding.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Fixed `email()` accepting U+017F (long s) and U+212A (Kelvin sign), e.g. `ſ@example.com`, and `url()` accepting them in a scheme. RFC 5321/RFC 1035 email addresses and WHATWG URL schemes are ASCII-only.

--- a/.changeset/regex-common-branch-first.md
+++ b/.changeset/regex-common-branch-first.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Sped up the `date()`, `datetime()` and `time()` validators. Valid dates and datetimes parse ~5-7% faster.

--- a/.changeset/standard-schema-props-cache.md
+++ b/.changeset/standard-schema-props-cache.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-`schema['~standard'].validate(value)` is ~18% faster on valid objects, ~7% on invalid, and more on primitives.

--- a/.changeset/url-host-fast-accept.md
+++ b/.changeset/url-host-fast-accept.md
@@ -1,5 +1,0 @@
----
-"@paseri/paseri": patch
----
-
-Fixed `url()` accepting invalid URLs whose host the WHATWG parser rejects: a label starting with `xn--` that is invalid punycode (e.g. `http://xn--a.com`), or a host whose last label is a number that fails IPv4 parsing (e.g. `http://a.1`).

--- a/paseri-compiler/CHANGELOG.md
+++ b/paseri-compiler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paseri/compiler
 
+## 0.7.7
+
+### Patch Changes
+
+- acbf288: Compiled modules validate invalid inputs ~7-10% faster through the Standard Schema interface.
+
 ## 0.7.6
 
 ### Patch Changes

--- a/paseri-compiler/deno.json
+++ b/paseri-compiler/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/compiler",
   "license": "MIT",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Ahead-of-time compiler for Paseri schemas.",
   "exports": {
     ".": "./src/index.ts"

--- a/paseri-lib/CHANGELOG.md
+++ b/paseri-lib/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @paseri/paseri
 
+## 1.9.7
+
+### Patch Changes
+
+- c87e4c9: `p.string().ip()` and `p.string().cidr()` now reject IPv6 zone IDs containing U+212A (Kelvin sign) or U+017F (long s), e.g. `fe80::1%ſ1`; zone IDs are ASCII-only per RFC 6874.
+- 6531b82: Fixed `email()` accepting U+017F (long s) and U+212A (Kelvin sign), e.g. `ſ@example.com`, and `url()` accepting them in a scheme. RFC 5321/RFC 1035 email addresses and WHATWG URL schemes are ASCII-only.
+- d106235: Sped up the `date()`, `datetime()` and `time()` validators. Valid dates and datetimes parse ~5-7% faster.
+- acbf288: `schema['~standard'].validate(value)` is ~18% faster on valid objects, ~7% on invalid, and more on primitives.
+- cb6197e: Fixed `url()` accepting invalid URLs whose host the WHATWG parser rejects: a label starting with `xn--` that is invalid punycode (e.g. `http://xn--a.com`), or a host whose last label is a number that fails IPv4 parsing (e.g. `http://a.1`).
+
 ## 1.9.6
 
 ### Patch Changes

--- a/paseri-lib/deno.json
+++ b/paseri-lib/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
   "name": "@paseri/paseri",
   "license": "MIT",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "exports": {
     ".": "./src/index.ts",
     "./internal": "./src/internal/index.ts",


### PR DESCRIPTION
## @paseri/paseri 1.9.7

### Patch Changes

- c87e4c9: `p.string().ip()` and `p.string().cidr()` now reject IPv6 zone IDs containing U+212A (Kelvin sign) or U+017F (long s), e.g. `fe80::1%ſ1`; zone IDs are ASCII-only per RFC 6874.
- 6531b82: Fixed `email()` accepting U+017F (long s) and U+212A (Kelvin sign), e.g. `ſ@example.com`, and `url()` accepting them in a scheme. RFC 5321/RFC 1035 email addresses and WHATWG URL schemes are ASCII-only.
- d106235: Sped up the `date()`, `datetime()` and `time()` validators. Valid dates and datetimes parse ~5-7% faster.
- acbf288: `schema['~standard'].validate(value)` is ~18% faster on valid objects, ~7% on invalid, and more on primitives.
- cb6197e: Fixed `url()` accepting invalid URLs whose host the WHATWG parser rejects: a label starting with `xn--` that is invalid punycode (e.g. `http://xn--a.com`), or a host whose last label is a number that fails IPv4 parsing (e.g. `http://a.1`).

## @paseri/compiler 0.7.7

### Patch Changes

- acbf288: Compiled modules validate invalid inputs ~7-10% faster through the Standard Schema interface.